### PR TITLE
feat: one step build and publish

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -5,6 +5,22 @@ build-GoExampleExtensionLayer:
 	GOOS=linux GOARCH=amd64 go build -o $(ARTIFACTS_DIR)/extensions/apm-lambda-extension main.go
 	chmod +x $(ARTIFACTS_DIR)/extensions/apm-lambda-extension
 
+build-and-publish:
+ifndef AWS_DEFAULT_REGION
+	$(error AWS_DEFAULT_REGION is undefined)
+endif
+ifndef AWS_ACCESS_KEY_ID
+	$(error AWS_ACCESS_KEY_ID is undefined)
+endif
+ifndef AWS_SECRET_ACCESS_KEY
+	$(error AWS_SECRET_ACCESS_KEY is undefined)
+endif
+ifndef ELASTIC_LAYER_NAME
+	$(error ELASTIC_LAYER_NAME is undefined)
+endif
+	make build
+	cd bin && rm extension.zip || true && zip -r extension.zip extensions
+	aws lambda publish-layer-version --layer-name "${ELASTIC_LAYER_NAME}" --zip-file "fileb://./bin/extension.zip"
 run-GoExampleExtensionLayer:
 	go run apm-lambda-extension/main.go
 

--- a/apm-lambda-extension/README.md
+++ b/apm-lambda-extension/README.md
@@ -51,6 +51,16 @@ The out from the above command will include a `LayverVersionArn` field, which co
 
 This is the string you'll enter in the AWS Lambda Console to add this layer to your Lambda function.
 
+## One Step Build
+
+The `Makefile` also provides a `build-and-publish` command which will perform the above steps for use, using ENV variable for credentials and other information.
+
+    $ ELASTIC_LAYER_NAME=apm-lambda-extension \
+    AWS_DEFAULT_REGION=us-west-2 \
+    AWS_ACCESS_KEY_ID=A...X \
+    AWS_SECRET_ACCESS_KEY=h...E \
+    make build-and-publish
+
 ## Configure the Agent
 
     TODO: instructions on configuring the agent


### PR DESCRIPTION
Part of https://github.com/elastic/apm-aws-lambda/issues/6

This PR adds a `build-and-publish` makefile command that, in one step, can build and publish the latest source as an AWS layer.