### PR TITLE
Return error from function posting to APM server

### DIFF
--- a/apm-lambda-extension/extension/apm_server.go
+++ b/apm-lambda-extension/extension/apm_server.go
@@ -11,7 +11,7 @@ import (
 // todo: can this be a streaming or streaming style call that keeps the
 //       connection open across invocations?
 // func PostToApmServer(postBody []byte, apmServerEndpoint string, apmServerSecretToken string) {
-func PostToApmServer(postBody []byte, config *extensionConfig) {
+func PostToApmServer(postBody []byte, config *extensionConfig) error {
 	var compressedBytes bytes.Buffer
 	w := gzip.NewWriter(&compressedBytes)
 	w.Write(postBody)
@@ -34,7 +34,7 @@ func PostToApmServer(postBody []byte, config *extensionConfig) {
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatalf("An Error Occured calling client.Do %v", err)
+		return err
 	}
 
 	//Read the response body
@@ -49,4 +49,6 @@ func PostToApmServer(postBody []byte, config *extensionConfig) {
 	sb := string(body)
 	log.Printf("Response Headers: %v\n", resp.Header)
 	log.Printf("Response Body: %v\n", sb)
+
+	return nil
 }

--- a/apm-lambda-extension/extension/process_events.go
+++ b/apm-lambda-extension/extension/process_events.go
@@ -14,9 +14,12 @@ func FlushAPMData(dataChannel chan []byte, config *extensionConfig) {
 	log.Println("Checking for agent data")
 	for {
 		select {
-		case agentBytes := <-dataChannel:
+		case agentData := <-dataChannel:
 			log.Println("Received bytes from data channel")
-			PostToApmServer(agentBytes, config)
+			err := PostToApmServer(agentData, config)
+			if err != nil {
+				log.Printf("Error sending to APM server: %v", err)
+			}
 		default:
 			log.Println("No more agent data")
 			return

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -10,7 +10,7 @@ func handleIntakeV2Events(handler *serverHandler, w http.ResponseWriter, r *http
 	if nil != err {
 		log.Println("could not get bytes from body")
 	} else {
-		log.Println("Receiving bytes from request")
+		log.Println("Receiving bytes from agent request")
 		handler.data <- bodyBytes
 	}
 	w.WriteHeader(http.StatusAccepted)

--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -82,7 +82,7 @@ func main() {
 				log.Println("Exiting")
 				return
 			}
-			log.Printf("Received event: %v\n", extension.PrettyPrint(res))
+			log.Printf("Received event: %v\n", extension.PrettyPrint(event))
 
 			// A shutdown event indicates the execution environment is shutting down.
 			// This is usually due to inactivity.
@@ -111,7 +111,10 @@ func main() {
 						log.Println("Function invocation is complete, not receiving any more agent data")
 						return
 					case agentData := <-dataChannel:
-						extension.PostToApmServer(agentData, config)
+						err := extension.PostToApmServer(agentData, config)
+						if err != nil {
+							log.Printf("Error sending to APM server: %v", err)
+						}
 					}
 				}
 			}()


### PR DESCRIPTION
We are currently continuing the function even if there's an error posting to the APM server. These changes return an error from the function if there's an error sending to the APM server.

Resolves #27