### PR TITLE
feat: updating env var for extension

### DIFF
--- a/apm-lambda-extension/extension/process_env.go
+++ b/apm-lambda-extension/extension/process_env.go
@@ -31,12 +31,12 @@ func ProcessEnv() *extensionConfig {
 	endpointUri := "/intake/v2/events"
 	dataReceiverTimeoutSeconds, err := getIntFromEnv("ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS")
 	if err != nil {
-		log.Printf("Error reading ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS, defaulting to 15: %v\n", err)
+		log.Printf("Could not read ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS, defaulting to 15: %v\n", err)
 		dataReceiverTimeoutSeconds = 15
 	}
 
 	config := &extensionConfig{
-		apmServerEndpoint:          os.Getenv("ELASTIC_APM_SERVER_URL") + endpointUri,
+		apmServerEndpoint:          os.Getenv("ELASTIC_APM_LAMBDA_APM_SERVER") + endpointUri,
 		apmServerSecretToken:       os.Getenv("ELASTIC_APM_SECRET_TOKEN"),
 		apmServerApiKey:            os.Getenv("ELASTIC_APM_API_KEY"),
 		dataReceiverServerPort:     os.Getenv("ELASTIC_APM_DATA_RECEIVER_SERVER_PORT"),
@@ -47,7 +47,7 @@ func ProcessEnv() *extensionConfig {
 		config.dataReceiverServerPort = ":8200"
 	}
 	if endpointUri == config.apmServerEndpoint {
-		log.Fatalln("please set ELASTIC_APM_SERVER_URL, exiting")
+		log.Fatalln("please set ELASTIC_APM_LAMBDA_APM_SERVER, exiting")
 	}
 	if config.apmServerSecretToken == "" && config.apmServerApiKey == "" {
 		log.Fatalln("please set ELASTIC_APM_SECRET_TOKEN or ELASTIC_APM_API_KEY, exiting")

--- a/apm-lambda-extension/extension/process_env_test.go
+++ b/apm-lambda-extension/extension/process_env_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestNewPersonPositiveAge(t *testing.T) {
-	os.Setenv("ELASTIC_APM_SERVER_URL", "foo.example.com")
+	os.Setenv("ELASTIC_APM_LAMBDA_APM_SERVER", "foo.example.com")
 	os.Setenv("ELASTIC_APM_SECRET_TOKEN", "bar")
 
 	config := ProcessEnv()


### PR DESCRIPTION
Implements #17.

This PR changes the extension such that it looks for the APM Server value in `ELASTIC_APM_LAMBDA_APM_SERVER` instead of `ELASTIC_APM_SERVER_URL`.