### PR TITLE
Change Env variable for logs listener, use address, add tests

### DIFF
--- a/apm-lambda-extension/logsapi/http_listener.go
+++ b/apm-lambda-extension/logsapi/http_listener.go
@@ -6,11 +6,9 @@ package logsapi
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"time"
 )
@@ -48,13 +46,9 @@ func ListenOnAddress() string {
 		return ":" + DefaultHttpListenerPort
 	}
 
-	listenerAddress, ok := os.LookupEnv("ELASTIC_APM_DATA_RECEIVER_LOG_LISTENER_ADDRESS")
-
+	listenerAddress, ok := os.LookupEnv("ELASTIC_APM_LAMBDA_LOGS_LISTENER_ADDRESS")
 	if ok && listenerAddress != "" {
-		u, err := url.Parse(listenerAddress)
-		if err == nil {
-			return fmt.Sprintf("%s:%s", u.Host, u.Port())
-		}
+		return listenerAddress
 	}
 	return "sandbox:" + DefaultHttpListenerPort
 }

--- a/apm-lambda-extension/logsapi/http_listener_test.go
+++ b/apm-lambda-extension/logsapi/http_listener_test.go
@@ -1,0 +1,29 @@
+package logsapi
+
+import (
+	"os"
+	"testing"
+)
+
+func TestListenOnAddressWithENVVariable(t *testing.T) {
+	os.Setenv("ELASTIC_APM_LAMBDA_LOGS_LISTENER_ADDRESS", "example:3456")
+
+	address := ListenOnAddress()
+	t.Logf("%v", address)
+
+	if address != "example:3456" {
+		t.Log("Address was not taken from ENV variable correctly")
+		t.Fail()
+	}
+}
+
+func TestListenOnAddressDefault(t *testing.T) {
+	os.Unsetenv("ELASTIC_APM_LAMBDA_LOGS_LISTENER_ADDRESS")
+	address := ListenOnAddress()
+	t.Logf("%v", address)
+
+	if address != "sandbox:1234" {
+		t.Log("Default address was not used")
+		t.Fail()
+	}
+}


### PR DESCRIPTION
This PR changes the ENV variable for the logs listener address to `ELASTIC_APM_LAMBDA_LOGS_LISTENER_ADDRESS`
It also assumes the ENV variable will be an address, not a URL (no scheme included)

It also adds tests for the `listenOnAddress` function.