### PR TITLE
Set logs api buffering timeout to minimum (25ms)

### DIFF
--- a/apm-lambda-extension/logsapi/init.go
+++ b/apm-lambda-extension/logsapi/init.go
@@ -43,7 +43,7 @@ func Subscribe(extensionID string, eventTypes []EventType) error {
 	bufferingCfg := BufferingCfg{
 		MaxItems:  10000,
 		MaxBytes:  262144,
-		TimeoutMS: 1000,
+		TimeoutMS: 25,
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, the logs api buffering timeout was set to 1000ms and we saw a delay in when the extension received a `runtimeDone` event. This wasted a lot of time in the extension.
This PR changes the value to the minimum, 25ms.