### PR TITLE
fix: prevent // in APM Server URL

### DIFF
--- a/apm-lambda-extension/extension/apm_server.go
+++ b/apm-lambda-extension/extension/apm_server.go
@@ -29,7 +29,7 @@ import (
 // todo: can this be a streaming or streaming style call that keeps the
 //       connection open across invocations?
 func PostToApmServer(postBody []byte, config *extensionConfig) error {
-	endpointUri := "/intake/v2/events"
+	endpointUri := "intake/v2/events"
 	var compressedBytes bytes.Buffer
 	w := gzip.NewWriter(&compressedBytes)
 	w.Write(postBody)
@@ -50,6 +50,7 @@ func PostToApmServer(postBody []byte, config *extensionConfig) error {
 	} else if config.apmServerSecretToken != "" {
 		req.Header.Add("Authorization", "Bearer "+config.apmServerSecretToken)
 	}
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to post to APM server: %v", err)


### PR DESCRIPTION
Closes: #42

Fixes a bug/oversight where the APM Server URL was generated with two slashes despite us going out of our way to normalize the slashes on the configured URL.

```
http://apm.example.com//intake/v2/events
```