### PR TITLE
Return an error if the logs API is not supported when attempting to subscribe to it

### DIFF
--- a/apm-lambda-extension/logsapi/client.go
+++ b/apm-lambda-extension/logsapi/client.go
@@ -153,6 +153,7 @@ func (c *Client) Subscribe(types []EventType, bufferingCfg BufferingCfg, destina
 
 	if resp.StatusCode == http.StatusAccepted {
 		log.Println("Logs API is not supported. Is this extension running in a local sandbox?")
+		return nil, errors.Errorf("Logs API is not supported in this environment")
 	} else if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
I noticed that we should return an error if the logs API is not supported instead of continuing the `subscribe` function.