### PR TITLE
Refactor route handling and server

### DIFF
--- a/apm-lambda-extension/extension/http_server.go
+++ b/apm-lambda-extension/extension/http_server.go
@@ -37,8 +37,8 @@ func StartHttpServer(agentDataChan chan AgentData, config *extensionConfig) (err
 	}
 
 	go func() {
-		agentDataServer.Serve(ln)
 		log.Printf("Extension listening for apm data on %s", agentDataServer.Addr)
+		agentDataServer.Serve(ln)
 	}()
 	return nil
 }

--- a/apm-lambda-extension/extension/http_server.go
+++ b/apm-lambda-extension/extension/http_server.go
@@ -22,17 +22,17 @@ import (
 	"net/http"
 )
 
-var extensionServer *http.Server
+var agentDataServer *http.Server
 
 func StartHttpServer(agentDataChan chan AgentData, config *extensionConfig) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleInfoRequest(config.apmServerUrl))
 	mux.HandleFunc("/intake/v2/events", handleIntakeV2Events(agentDataChan))
-	extensionServer = &http.Server{Addr: config.dataReceiverServerPort, Handler: mux}
+	agentDataServer = &http.Server{Addr: config.dataReceiverServerPort, Handler: mux}
 
 	go func() {
-		log.Printf("Extension liistening for apm data on %s", extensionServer.Addr)
-		err := extensionServer.ListenAndServe()
+		log.Printf("Extension listening for apm data on %s", agentDataServer.Addr)
+		err := agentDataServer.ListenAndServe()
 		if err != http.ErrServerClosed {
 			log.Printf("Unexpected stop on Extension Server: %v", err)
 		} else {

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -46,7 +46,7 @@ func TestInfoProxy(t *testing.T) {
 		apmServerUrl:               apmServer.URL,
 		apmServerSecretToken:       "foo",
 		apmServerApiKey:            "bar",
-		dataReceiverServerPort:     "localhost:1234",
+		dataReceiverServerPort:     "127.0.0.1:4567",
 		dataReceiverTimeoutSeconds: 15,
 	}
 

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -46,7 +46,7 @@ func TestInfoProxy(t *testing.T) {
 		apmServerUrl:               apmServer.URL,
 		apmServerSecretToken:       "foo",
 		apmServerApiKey:            "bar",
-		dataReceiverServerPort:     "127.0.0.1:1234",
+		dataReceiverServerPort:     "localhost:1234",
 		dataReceiverTimeoutSeconds: 15,
 	}
 

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -51,11 +51,11 @@ func TestInfoProxy(t *testing.T) {
 	}
 
 	StartHttpServer(dataChannel, &config)
-	defer extensionServer.Close()
+	defer agentDataServer.Close()
 
 	// Create a request to send to the extension
 	client := &http.Client{}
-	url := "http://" + extensionServer.Addr
+	url := "http://" + agentDataServer.Addr
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Logf("Could not create request")
@@ -67,7 +67,7 @@ func TestInfoProxy(t *testing.T) {
 	// Send the request to the extension
 	resp, err := client.Do(req)
 	if err != nil {
-		t.Logf("Error fetching %s, [%v]", extensionServer.Addr, err)
+		t.Logf("Error fetching %s, [%v]", agentDataServer.Addr, err)
 		t.Fail()
 	} else {
 		body, _ := ioutil.ReadAll(resp.Body)

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -49,7 +49,8 @@ func TestInfoProxy(t *testing.T) {
 		dataReceiverServerPort:     "127.0.0.1:1234",
 		dataReceiverTimeoutSeconds: 15,
 	}
-	extensionServer := NewHttpServer(dataChannel, &config)
+
+	StartHttpServer(dataChannel, &config)
 	defer extensionServer.Close()
 
 	// Create a request to send to the extension

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"gotest.tools/assert"
 )
@@ -67,7 +66,6 @@ func TestInfoProxy(t *testing.T) {
 		req.Header.Add(name, value)
 	}
 
-	time.Sleep(2 * time.Second)
 	// Send the request to the extension
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -46,7 +46,7 @@ func TestInfoProxy(t *testing.T) {
 		apmServerUrl:               apmServer.URL,
 		apmServerSecretToken:       "foo",
 		apmServerApiKey:            "bar",
-		dataReceiverServerPort:     "127.0.0.1:4567",
+		dataReceiverServerPort:     ":4567",
 		dataReceiverTimeoutSeconds: 15,
 	}
 

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -46,7 +46,7 @@ func TestInfoProxy(t *testing.T) {
 		apmServerUrl:               apmServer.URL,
 		apmServerSecretToken:       "foo",
 		apmServerApiKey:            "bar",
-		dataReceiverServerPort:     ":4567",
+		dataReceiverServerPort:     ":1234",
 		dataReceiverTimeoutSeconds: 15,
 	}
 
@@ -55,8 +55,7 @@ func TestInfoProxy(t *testing.T) {
 
 	// Create a request to send to the extension
 	client := &http.Client{}
-	url := "http://localhost" + agentDataServer.Addr
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequest("GET", "http://localhost:1234", nil)
 	if err != nil {
 		t.Logf("Could not create request")
 	}

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -55,7 +55,7 @@ func TestInfoProxy(t *testing.T) {
 
 	// Create a request to send to the extension
 	client := &http.Client{}
-	url := "http://" + agentDataServer.Addr
+	url := "http://localhost" + agentDataServer.Addr
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		t.Logf("Could not create request")

--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -30,7 +31,6 @@ import (
 func TestInfoProxy(t *testing.T) {
 	headers := map[string]string{"Authorization": "test-value"}
 	wantResp := "{\"foo\": \"bar\"}"
-	var url string
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -56,11 +56,7 @@ func TestInfoProxy(t *testing.T) {
 	defer agentDataServer.Close()
 
 	hosts, _ := net.LookupHost("localhost")
-	if hosts[0] == "::1" {
-		url = "http://" + "[::1]" + ":1234"
-	} else {
-		url = "http://" + hosts[0] + ":1234"
-	}
+	url := "http://" + hosts[0] + ":1234"
 
 	// Create a request to send to the extension
 	req, err := http.NewRequest("GET", url, nil)
@@ -71,6 +67,7 @@ func TestInfoProxy(t *testing.T) {
 		req.Header.Add(name, value)
 	}
 
+	time.Sleep(2 * time.Second)
 	// Send the request to the extension
 	client := &http.Client{}
 	resp, err := client.Do(req)

--- a/apm-lambda-extension/extension/process_events.go
+++ b/apm-lambda-extension/extension/process_events.go
@@ -26,6 +26,7 @@ import (
 func ProcessShutdown() {
 	log.Println("Received SHUTDOWN event")
 	log.Println("Exiting")
+	agentDataServer.Close()
 }
 
 func FlushAPMData(client *http.Client, dataChannel chan AgentData, config *extensionConfig) {

--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -64,7 +64,7 @@ func main() {
 	// and get a channel to listen for that data
 	agentDataChannel := make(chan extension.AgentData, 100)
 
-	extension.NewHttpServer(agentDataChannel, config)
+	extension.StartHttpServer(agentDataChannel, config)
 
 	// Make channel for collecting logs and create a HTTP server to listen for them
 	logsChannel := make(chan logsapi.LogEvent)


### PR DESCRIPTION
While working on #62, I found that it was awkward to find a way to pass the channel signaling that the function completed to the router handler. In defining the handlers as they are in this PR, we can easily pass the channel to the handler function, without having to keep a reference to it somewhere.