### PR TITLE
Use query param to intake API to signal that function completed

### DIFF
--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -18,12 +18,14 @@
 package extension
 
 import (
+	"bytes"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -82,15 +84,7 @@ func TestInfoProxy(t *testing.T) {
 	}
 }
 
-<<<<<<< HEAD
 func TestInfoProxyErrorStatusCode(t *testing.T) {
-=======
-func Test_handleIntakeV2EventsQueryParam(t *testing.T) {
-	body := []byte(`{"metadata": {}`)
-
-	FuncDone = make(chan struct{})
-
->>>>>>> Check length of query param slice before accessing index
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(401)
@@ -174,10 +168,60 @@ func Test_handleInfoRequest(t *testing.T) {
 	}
 }
 
-func Test_handleIntakeV2EventsNoQueryParam(t *testing.T) {
+func Test_handleIntakeV2EventsQueryParam(t *testing.T) {
 	body := []byte(`{"metadata": {}`)
 
-	FuncDone = make(chan struct{})
+	AgentDoneSignal = make(chan struct{})
+
+	// Create apm server and handler
+	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer apmServer.Close()
+
+	// Create extension config and start the server
+	dataChannel := make(chan AgentData, 100)
+	config := extensionConfig{
+		apmServerUrl:               apmServer.URL,
+		dataReceiverServerPort:     ":1234",
+		dataReceiverTimeoutSeconds: 15,
+	}
+
+	StartHttpServer(dataChannel, &config)
+	defer agentDataServer.Close()
+
+	hosts, _ := net.LookupHost("localhost")
+	url := "http://" + hosts[0] + ":1234/intake/v2/events?flushed=true"
+
+	// Create a request to send to the extension
+	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	if err != nil {
+		t.Logf("Could not create request")
+	}
+
+	// Send the request to the extension
+	client := &http.Client{}
+	go func() {
+		_, err := client.Do(req)
+		if err != nil {
+			t.Logf("Error fetching %s, [%v]", agentDataServer.Addr, err)
+			t.Fail()
+		}
+	}()
+
+	timer := time.NewTimer(1 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case <-AgentDoneSignal:
+		<-dataChannel
+	case <-timer.C:
+		t.Log("Timed out waiting for server to send FuncDone signal")
+		t.Fail()
+	}
+}
+
+func Test_handleIntakeV2EventsNoQueryParam(t *testing.T) {
+	body := []byte(`{"metadata": {}`)
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -211,5 +255,6 @@ func Test_handleIntakeV2EventsNoQueryParam(t *testing.T) {
 		t.Logf("Error fetching %s, [%v]", agentDataServer.Addr, err)
 		t.Fail()
 	}
+	<-dataChannel
 	assert.Equal(t, 202, resp.StatusCode)
 }

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -29,7 +29,7 @@ type AgentData struct {
 	ContentEncoding string
 }
 
-var FuncDone chan struct{}
+var AgentDoneSignal chan struct{}
 
 // URL: http://server/
 func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +101,7 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		agentDataChan <- agentData
 
 		if len(r.URL.Query()["flushed"]) > 0 && r.URL.Query()["flushed"][0] == "true" {
-			FuncDone <- struct{}{}
+			AgentDoneSignal <- struct{}{}
 		}
 	}
 }

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -29,6 +29,8 @@ type AgentData struct {
 	ContentEncoding string
 }
 
+var FuncDone chan struct{}
+
 // URL: http://server/
 func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -97,5 +99,9 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		}
 		log.Println("Adding agent data to buffer to be sent to apm server")
 		agentDataChan <- agentData
+
+		if r.URL.Query()["flushed"][0] == "true" {
+			FuncDone <- struct{}{}
+		}
 	}
 }

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -100,7 +100,7 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		log.Println("Adding agent data to buffer to be sent to apm server")
 		agentDataChan <- agentData
 
-		if r.URL.Query()["flushed"][0] == "true" {
+		if len(r.URL.Query()["flushed"]) > 0 && r.URL.Query()["flushed"][0] == "true" {
 			FuncDone <- struct{}{}
 		}
 	}

--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -116,8 +116,8 @@ func main() {
 			// Make a channel for signaling that the function invocation is complete
 			funcDone := make(chan struct{})
 
-			// Flush any APM data, in case waiting for the FuncDone signal timed out,
-			// the agent data wasn't available yet, and we got to the next event
+			// Flush any APM data, in case waiting for the agentDone or runtimeDone signals
+			// timed out, the agent data wasn't available yet, and we got to the next event
 			extension.FlushAPMData(client, agentDataChannel, config)
 
 			// A shutdown event indicates the execution environment is shutting down.
@@ -170,7 +170,7 @@ func main() {
 				}
 			}()
 
-			// Calculate how long to wait for a FuncDone signal
+			// Calculate how long to wait for a runtimeDoneSignal or AgentDoneSignal signal
 			flushDeadlineMs := event.DeadlineMs - 100
 			durationUntilFlushDeadline := time.Until(time.Unix(flushDeadlineMs/1000, 0))
 

--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -142,7 +142,7 @@ func main() {
 			}()
 
 			// Receive Logs API events
-			// Send to the runtimeDone channel to signal when a runtimeDone event is received
+			// Send to the FuncDone channel to signal when a runtimeDone event is received
 			go func() {
 				for {
 					select {


### PR DESCRIPTION
This PR adds a change to signal on a channel when it receives an intake request from an agent containing the query param "flushed=true".
We can change the name of the query param, if that's not clear enough.

As a fallback, it also signals if it receives a `runtimeDone` event from the logsapi.

There are now three channels used to signal in main. The `AgentDoneSignal` signals that there was an intake request received with `flushed=true`, the `runtimeDoneSignal` channel signals that a runtimeDone event was received via the Logs API. The `funcDone` channel is closed if a signal is received on `AgentDoneSignal` or `runtimeDoneSignal`.
Closing that channel signals to the go routines posting apm data and processing logs API events that they can return.

Resolves #62