### PR TITLE
Use copy for info response and add intake test

### DIFF
--- a/apm-lambda-extension/extension/http_server_test.go
+++ b/apm-lambda-extension/extension/http_server_test.go
@@ -38,6 +38,7 @@ func TestInfoProxy(t *testing.T) {
 			assert.Equal(t, 1, len(r.Header[key]))
 			assert.Equal(t, headers[key], r.Header[key][0])
 		}
+		w.Header().Add("test", "header")
 		w.Write([]byte(`{"foo": "bar"}`))
 	}))
 	defer apmServer.Close()
@@ -76,6 +77,7 @@ func TestInfoProxy(t *testing.T) {
 	} else {
 		body, _ := ioutil.ReadAll(resp.Body)
 		assert.Equal(t, string(body), wantResp)
+		assert.Equal(t, "header", resp.Header.Get("test"))
 		resp.Body.Close()
 	}
 }

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -84,11 +84,6 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		w.WriteHeader(http.StatusAccepted)
 		w.Write([]byte("ok"))
 
-		if r.Body == nil {
-			log.Println("No body in agent request")
-			return
-		}
-
 		rawBytes, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			log.Println("Could not read bytes from agent request body")

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -18,6 +18,7 @@
 package extension
 
 import (
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -46,30 +47,33 @@ func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.
 			return
 		}
 
-		resp, err := client.Do(req)
+		// Send request to apm server
+		serverResp, err := client.Do(req)
 		if err != nil {
 			log.Printf("error forwarding info request (`/`) to APM Server: %v", err)
 			return
 		}
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
+
+		// If WriteHeader is not called explicitly, the first call to Write
+		// will trigger an implicit WriteHeader(http.StatusOK).
+		if serverResp.StatusCode != 200 {
+			w.WriteHeader(serverResp.StatusCode)
+		}
+
+		// copy body to request sent back to the agent
+		_, err = io.Copy(w, serverResp.Body)
 		if err != nil {
 			log.Printf("could not read info request response to APM Server: %v", err)
 			return
 		}
 
-		// send status code
-		w.WriteHeader(resp.StatusCode)
-
 		// send every header received
-		for name, values := range resp.Header {
+		for name, values := range serverResp.Header {
 			// Loop over all values for the name.
 			for _, value := range values {
 				w.Header().Add(name, value)
 			}
 		}
-		// send body
-		w.Write([]byte(body))
 	}
 }
 

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -85,6 +85,7 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		w.Write([]byte("ok"))
 
 		rawBytes, err := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
 		if err != nil {
 			log.Println("Could not read bytes from agent request body")
 			return

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -60,19 +60,19 @@ func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.
 			w.WriteHeader(serverResp.StatusCode)
 		}
 
-		// copy body to request sent back to the agent
-		_, err = io.Copy(w, serverResp.Body)
-		if err != nil {
-			log.Printf("could not read info request response to APM Server: %v", err)
-			return
-		}
-
 		// send every header received
 		for name, values := range serverResp.Header {
 			// Loop over all values for the name.
 			for _, value := range values {
 				w.Header().Add(name, value)
 			}
+		}
+
+		// copy body to request sent back to the agent
+		_, err = io.Copy(w, serverResp.Body)
+		if err != nil {
+			log.Printf("could not read info request response to APM Server: %v", err)
+			return
 		}
 	}
 }


### PR DESCRIPTION
This PR contains these changes:

- Uses copy as per @stuartnelson3's [suggestion](https://github.com/elastic/apm-aws-lambda/pull/78/files#r753004695) to forward the apm server's info response back to the agent
- It adds an intake test and a test that the extension forwards an error from an info request
- Removes a check that the body is nil, as the documentation says it won't ever be nil