### PR TITLE
feat: remove unused command/event

### DIFF
--- a/apm-lambda-extension/cli/package.json
+++ b/apm-lambda-extension/cli/package.json
@@ -4,8 +4,7 @@
   "description": "cli for configuring lambda",
   "main": "cli.js",
   "scripts": {
-    "test": "tap --no-coverage tests/*.test.js",
-    "install": "./elastic-lambda.js install"
+    "test": "tap --no-coverage tests/*.test.js"
   },
   "author": "",
   "license": "BSD-2-Clause",


### PR DESCRIPTION
The `install` script is

1. Not used or mentioned in docs
2. Interferes with Node's `install` lifecycle event

This PR removes it. 