### PR TITLE
Link to built-docs instead of asciidoc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 This repository contains code and tools for working with Elastic APM's AWS Lambda solution.  
 
-If you're looking to get started with Elastic's AWS Lambda extension and agent instrumentation, the [AWS Lambda Extension](https://github.com/elastic/apm-aws-lambda/blob/main/docs/aws-lambda-extension.asciidoc) documentation is the place to start. 
+If you're looking to get started with Elastic's AWS Lambda extension and agent instrumentation, the [AWS Lambda Extension](https://www.elastic.co/guide/en/apm/guide/current/aws-lambda-extension.html) documentation is the place to start. 


### PR DESCRIPTION
Now that docs are included in the APM Guide (see https://github.com/elastic/apm-server/pull/6984), we should link to the docs instead of the asciidoc file.