### PR TITLE
Add test that flushed query param is processed even with empty data

### DIFF
--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -93,12 +93,14 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 			return
 		}
 
-		agentData := AgentData{
-			Data:            rawBytes,
-			ContentEncoding: r.Header.Get("Content-Encoding"),
+		if len(rawBytes) > 0 {
+			agentData := AgentData{
+				Data:            rawBytes,
+				ContentEncoding: r.Header.Get("Content-Encoding"),
+			}
+			log.Println("Adding agent data to buffer to be sent to apm server")
+			agentDataChan <- agentData
 		}
-		log.Println("Adding agent data to buffer to be sent to apm server")
-		agentDataChan <- agentData
 
 		if len(r.URL.Query()["flushed"]) > 0 && r.URL.Query()["flushed"][0] == "true" {
 			AgentDoneSignal <- struct{}{}


### PR DESCRIPTION
I've also added a change to only add data to the data channel if the length of the bytes received is > 0.