### PR TITLE
[jjbb] enable tag releases in Jenkins

### DIFF
--- a/.ci/jobs/apm-aws-lambda-mbp.yml
+++ b/.ci/jobs/apm-aws-lambda-mbp.yml
@@ -13,7 +13,7 @@
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
         discover-tags: true
-        head-filter-regex: '(main|PR-.*)'
+        head-filter-regex: '(main|PR-.*|v\d+\.\d+\.\d+.*)'
         notification-context: 'apm-ci'
         repo: apm-aws-lambda
         repo-owner: elastic


### PR DESCRIPTION
### What

Run builds in the CI for tag releases

### Why

Otherwise the changes in https://github.com/elastic/apm-aws-lambda/pull/101 won't be triggered