### PR TITLE
publish: some regions don't suppport CompatibleArchitectures

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -62,9 +62,8 @@ publish: validate-layer-name validate-aws-default-region
 		--output json \
 		publish-layer-version \
 		--layer-name "${ELASTIC_LAYER_NAME}" \
-		--description "AWS Lambda Extension Layer for Elastic APM" \
+		--description "AWS Lambda Extension Layer for Elastic APM $(ARCHITECTURE)" \
 		--license "Apache-2.0" \
-		--compatible-architectures "$(ARCHITECTURE)" \
 		--zip-file "fileb://./bin/extension.zip"
 
 # Generate the file with the ARN entries


### PR DESCRIPTION
Remove CompatibleArchitectures and use the arch in the description instead

```
An error occurred (InvalidParameterValueException) when calling the PublishLayerVersion operation: CompatibleArchitectures are not supported in af-south-1. Please remove the CompatibleArchitectures value from your request and try again
```