### PR TITLE
ci: notify when a release tag has been created and published

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -10,6 +10,9 @@ pipeline {
     PIPELINE_LOG_LEVEL = 'INFO'
     SUFFIX_ARN_FILE = 'arn-file.md'
     ELASTIC_LAYER_NAME = 'apm-lambda-extension'
+    RELEASE_URL_MESSAGE = "(<https://github.com/elastic/${env.REPO}/releases/tag/${env.TAG_NAME}|${env.TAG_NAME}>)"
+    SLACK_CHANNEL = '#apm-serverless'
+    NOTIFY_TO = 'build-apm+apm-serverless@elastic.co'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -27,6 +30,9 @@ pipeline {
   stages {
     stage('Checkout') {
       steps {
+        whenTrue(isTag()) {
+          notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release tag *${env.TAG_NAME}* has been created", body: "Build: (<${env.RUN_DISPLAY_URL}|here>) for further details.")
+        }
         deleteDir()
         gitCheckout(basedir: "${BASE_DIR}")
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
@@ -169,5 +175,24 @@ pipeline {
     cleanup {
       notifyBuildResult(prComment: true)
     }
+    success {
+      whenTrue(isTag()) {
+        notifyStatus(slackStatus: 'good', subject: "[${env.REPO}] Release *${env.TAG_NAME}* published", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)\nRelease URL: ${env.RELEASE_URL_MESSAGE}")
+      }
+    }
+    unsuccessful {
+      whenTrue(isTag()) {
+        notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release *${env.TAG_NAME}* could not be published.", body: "Build: (<${env.RUN_DISPLAY_URL}|here>)")
+      }
+    }
   }
+}
+
+def notifyStatus(def args = [:]) {
+  releaseNotification(slackChannel: "${env.SLACK_CHANNEL}",
+                      slackColor: args.slackStatus,
+                      slackCredentialsId: 'jenkins-slack-integration-token',
+                      to: "${env.NOTIFY_TO}",
+                      subject: args.subject,
+                      body: args.body)
 }


### PR DESCRIPTION
### What

Send email/slack message when a release tag is created and published/failed

### Why

Add visibility about the release process 
