### PR TITLE
ci: add info traces to help with debugging

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -133,6 +133,7 @@ pipeline {
                       withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', forceInstallation: true, version: '2.4.10') {
                         dir("${BASE_DIR}/apm-lambda-extension"){
                           cmd(label: 'make publish-in-all-aws-regions', script: 'make publish-in-all-aws-regions')
+                          cmd(label: 'make create-arn-file', script: 'make create-arn-file')
                           stash(includes: "*${SUFFIX_ARN_FILE}", name: "arn-${isArm() ? 'arm' : 'amd'}")
                           stash(includes: "bin/${BRANCH_NAME}-*.zip", name: "dist-${isArm() ? 'arm' : 'amd'}")
                         }
@@ -143,6 +144,7 @@ pipeline {
                 post {
                   always {
                     archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-lambda-extension/.regions")
+                    archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-lambda-extension/*${SUFFIX_ARN_FILE}")
                   }
                 }
               }

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -145,6 +145,7 @@ pipeline {
                   always {
                     archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-lambda-extension/.regions")
                     archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-lambda-extension/*${SUFFIX_ARN_FILE}")
+                    archiveArtifacts(allowEmptyArchive: true, artifacts: "${BASE_DIR}/apm-lambda-extension/.aws")
                   }
                 }
               }

--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -9,14 +9,19 @@ set -eo pipefail
 #	- SUFFIX_ARN_FILE - that's the output file.
 #
 
+ARN_FILE=${ARCHITECTURE}-${SUFFIX_ARN_FILE}
+
 {
 	echo "### ARCH: ${ARCHITECTURE}"
 	echo ''
 	echo '|Region|Arch|ARN|'
 	echo '|------|----|---|'
-	for f in $(ls "${AWS_FOLDER}"); do
-		# TODO: identify what field to be used.
-		echo "|${f}|${ARCHITECTURE}|$(cat $AWS_FOLDER/${f} | jq -r .LayerVersionArn)|"
-	done
-	echo ''
-} > ${ARCHITECTURE}-${SUFFIX_ARN_FILE}
+} > "${ARN_FILE}"
+
+for f in $(ls "${AWS_FOLDER}"); do
+	LAYER_VERSION_ARN=$(jq -r .LayerVersionArn "$AWS_FOLDER/${f}")
+	echo "INFO: create-arn-table ARN(${LAYER_VERSION_ARN}):region(${f}):arch(${ARCHITECTURE})"
+	echo "|${f}|${ARCHITECTURE}|${LAYER_VERSION_ARN}|" >> "${ARN_FILE}"
+done
+
+echo '' >> "${ARN_FILE}"

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -54,7 +54,6 @@ publish-in-all-aws-regions: validate-layer-name get-all-aws-regions
 		echo "publish '$(ELASTIC_LAYER_NAME)' in $${AWS_DEFAULT_REGION}"; \
 		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) publish > $(AWS_FOLDER)/$${AWS_DEFAULT_REGION}; \
 	done <.regions
-	$(MAKE) create-arn-file
 
 # Publish the given LAYER in the given AWS region
 publish: validate-layer-name validate-aws-default-region


### PR DESCRIPTION
### What

Add debug traces.
Store files generated while publishing the ARN lambda (the output from aws lambda  --output json  publish-layer-version)
Fix a parsing error in the CI that I was not able to reproduce it locally

```
12:29:09  make create-arn-file
12:29:09  make[1]: Entering directory '/var/lib/jenkins/workspace/ibrary_apm-aws-lambda-mbp_v0.0.3/src/github.com/elastic/apm-aws-lambda/apm-lambda-extension'
12:29:09  parse error: Invalid numeric literal at line 1, column 5
```
![image](https://user-images.githubusercontent.com/2871786/152162318-48a3f711-450f-4380-9e2d-3657a3deac37.png)

### Test

```bash
AWS_ACCESS_KEY_ID=*** \
AWS_SECRET_ACCESS_KEY=*** \
BRANCH_NAME=v0.0.0.1 \
SUFFIX_ARN_FILE=arn.md \
ELASTIC_LAYER_NAME=v1v-aws-lambda-test \
make publish-in-all-aws-regions
publish 'v1v-aws-lambda-test' in af-south-1
publish 'v1v-aws-lambda-test' in eu-north-1
publish 'v1v-aws-lambda-test' in ap-south-1
publish 'v1v-aws-lambda-test' in eu-west-3
publish 'v1v-aws-lambda-test' in eu-west-2
publish 'v1v-aws-lambda-test' in eu-south-1
publish 'v1v-aws-lambda-test' in eu-west-1
publish 'v1v-aws-lambda-test' in ap-northeast-3
publish 'v1v-aws-lambda-test' in ap-northeast-2
publish 'v1v-aws-lambda-test' in me-south-1
publish 'v1v-aws-lambda-test' in ap-northeast-1
publish 'v1v-aws-lambda-test' in sa-east-1
publish 'v1v-aws-lambda-test' in ca-central-1
publish 'v1v-aws-lambda-test' in ap-east-1
publish 'v1v-aws-lambda-test' in ap-southeast-1
publish 'v1v-aws-lambda-test' in ap-southeast-2
publish 'v1v-aws-lambda-test' in eu-central-1
publish 'v1v-aws-lambda-test' in ap-southeast-3
publish 'v1v-aws-lambda-test' in us-east-1
publish 'v1v-aws-lambda-test' in us-east-2
```

then

```
SUFFIX_ARN_FILE=arn.md make create-arn-file                          
INFO: create-arn-table ARN(arn:aws:lambda:af-south-1:267093732750:layer:v1v-aws-lambda-test:1):region(af-south-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-east-1:267093732750:layer:v1v-aws-lambda-test:1):region(ap-east-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-northeast-1:267093732750:layer:v1v-aws-lambda-test:1):region(ap-northeast-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-northeast-2:267093732750:layer:v1v-aws-lambda-test:1):region(ap-northeast-2):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-northeast-3:267093732750:layer:v1v-aws-lambda-test:1):region(ap-northeast-3):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-south-1:267093732750:layer:v1v-aws-lambda-test:1):region(ap-south-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-southeast-1:267093732750:layer:v1v-aws-lambda-test:1):region(ap-southeast-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-southeast-2:267093732750:layer:v1v-aws-lambda-test:1):region(ap-southeast-2):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ap-southeast-3:267093732750:layer:v1v-aws-lambda-test:1):region(ap-southeast-3):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:ca-central-1:267093732750:layer:v1v-aws-lambda-test:1):region(ca-central-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-central-1:267093732750:layer:v1v-aws-lambda-test:1):region(eu-central-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-north-1:267093732750:layer:v1v-aws-lambda-test:1):region(eu-north-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-south-1:267093732750:layer:v1v-aws-lambda-test:1):region(eu-south-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-west-1:267093732750:layer:v1v-aws-lambda-test:1):region(eu-west-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-west-2:267093732750:layer:v1v-aws-lambda-test:1):region(eu-west-2):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:eu-west-3:267093732750:layer:v1v-aws-lambda-test:1):region(eu-west-3):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:me-south-1:267093732750:layer:v1v-aws-lambda-test:1):region(me-south-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:sa-east-1:267093732750:layer:v1v-aws-lambda-test:1):region(sa-east-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:us-east-1:267093732750:layer:v1v-aws-lambda-test:1):region(us-east-1):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:us-east-2:267093732750:layer:v1v-aws-lambda-test:1):region(us-east-2):arch(x86_64)
INFO: create-arn-table ARN(arn:aws:lambda:us-west-1:267093732750:layer:v1v-aws-lambda-test:1):region(us-west-1):arch(x86_64)
```

![image](https://user-images.githubusercontent.com/2871786/152162591-35a61fb4-2fc2-40ec-8877-78683b7b581e.png)

### Important

As far as I see the output from publish-lambda does not contain any sensitive details unless the content.location is something to be careful about:

```
{
    "Content": {
        "Location": "https://prod-cpt-c0-h5e2y-layers.s3.af-south-1.amazonaws.com/snapshots/267093732750/v1v-aws-lambda-test-REDACTED?versionId=REDACTED&X-Amz-Security-Token=REDACTED&X-Amz-Algorithm=REDACTED&X-Amz-Date=20220202T132137Z&X-Amz-SignedHeaders=host&X-Amz-Expires=600&X-Amz-Credential=REDACTED%2F20220202%2Faf-south-1%2Fs3%2Faws4_request&X-Amz-Signature=REDACTED",
        "CodeSha256": "REDACTED",
        "CodeSize": 3839771
    },
    "LayerArn": "arn:aws:lambda:af-south-1:267093732750:layer:v1v-aws-lambda-test",
    "LayerVersionArn": "arn:aws:lambda:af-south-1:267093732750:layer:v1v-aws-lambda-test:1",
    "Description": "AWS Lambda Extension Layer for Elastic APM x86_64",
    "CreatedDate": "2022-02-02T13:21:40.835+0000",
    "Version": 1,
    "LicenseInfo": "Apache-2.0"
}
```