### PR TITLE
publish: make a layer public

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -53,6 +53,7 @@ publish-in-all-aws-regions: validate-layer-name get-all-aws-regions
 	@while read AWS_DEFAULT_REGION; do \
 		echo "publish '$(ELASTIC_LAYER_NAME)' in $${AWS_DEFAULT_REGION}"; \
 		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) publish > $(AWS_FOLDER)/$${AWS_DEFAULT_REGION}; \
+		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) grant-public-layer-access; \
 	done <.regions
 	$(MAKE) create-arn-file
 
@@ -65,6 +66,17 @@ publish: validate-layer-name validate-aws-default-region
 		--description "AWS Lambda Extension Layer for Elastic APM $(ARCHITECTURE)" \
 		--license "Apache-2.0" \
 		--zip-file "fileb://./bin/extension.zip"
+
+# Grant public access to the given LAYER in the given AWS region
+grant-public-layer-access: validate-layer-name validate-aws-default-region
+	@aws lambda \
+		--output json \
+		add-layer-version-permission \
+		--layer-name "$(ELASTIC_LAYER_NAME)" \
+		--action lambda:GetLayerVersion \
+		--principal '*' \
+		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
+		--version-number $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 
 # Generate the file with the ARN entries
 create-arn-file: validate-suffix-arn-file


### PR DESCRIPTION
### What

Publish the layer as a public layer

### Further details

https://docs.aws.amazon.com/lambda/latest/dg/access-control-resource-based.html#permissions-resource-xaccountlayer


### Test

```bash
$ AWS_ACCESS_KEY_ID=*** \
AWS_SECRET_ACCESS_KEY=*** \
AWS_DEFAULT_REGION=us-west-2 \
ELASTIC_LAYER_NAME=v1v-aws-lambda-test \
make grant-public-layer-access
```

produced

```
$ cat .aws/.us-west-2-public
{
    "Statement": "{\"Sid\":\"v1v-aws-lambda-test-x86_64\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"lambda:GetLayerVersion\",\"Resource\":\"arn:aws:lambda:us-west-2:267093732750:layer:v1v-aws-lambda-test:1\"}",
    "RevisionId": "d42f1c13-4c4a-4384-9d59-f052d7ef35ef"
}
```
