### PR TITLE
fix: use env variable for collector endpoint

### DIFF
--- a/apm-lambda-extension/cli/profile/code/collector.yaml
+++ b/apm-lambda-extension/cli/profile/code/collector.yaml
@@ -9,7 +9,7 @@ exporters:
     loglevel: debug
   otlp/elastic:
     # APM server https endpoint without https://
-    endpoint: "https://01cd7a0a66084992906782275a699198.apm.us-east-1.aws.cloud.es.io:443"
+    endpoint: "${ELASTIC_APM_SERVER_URL}"
     headers:
       # APM Server secret token
       Authorization: "Bearer ${APM_ELASTIC_SECRET_TOKEN}"


### PR DESCRIPTION
Remove hard coded APM Server URL for oTel sample application, use env variable as intended. 