### PR TITLE
fix layer-name when granting public access and get ARN version 

### DIFF
--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -o pipefail
 
 #
 # Create the AWS ARN table given the below environment variables:
@@ -19,7 +19,7 @@ ARN_FILE=${ARCHITECTURE}-${SUFFIX_ARN_FILE}
 } > "${ARN_FILE}"
 
 for f in $(ls "${AWS_FOLDER}"); do
-	LAYER_VERSION_ARN=$(jq -r .LayerVersionArn "$AWS_FOLDER/${f}")
+	LAYER_VERSION_ARN=$(grep '"LayerVersionArn"' "$AWS_FOLDER/${f}" | cut -d":" -f2- | sed 's/ //g' | sed 's/"//g' | cut -d"," -f1)
 	echo "INFO: create-arn-table ARN(${LAYER_VERSION_ARN}):region(${f}):arch(${ARCHITECTURE})"
 	echo "|${f}|${ARCHITECTURE}|${LAYER_VERSION_ARN}|" >> "${ARN_FILE}"
 done

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -69,7 +69,7 @@ publish: validate-layer-name validate-aws-default-region
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
 	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) get-version)"
-	aws lambda \
+	@aws lambda \
 		--output json \
 		add-layer-version-permission \
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -58,7 +58,7 @@ publish-in-all-aws-regions: validate-layer-name get-all-aws-regions
 
 # Publish the given LAYER in the given AWS region
 publish: validate-layer-name validate-aws-default-region
-	@aws lambda \
+	aws lambda \
 		--output json \
 		publish-layer-version \
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
@@ -68,7 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	@aws lambda \
+	aws lambda \
 		--output json \
 		add-layer-version-permission \
 		--layer-name "$(ELASTIC_LAYER_NAME)" \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -68,7 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) get-version)"
+	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) -s get-version)"
 	@aws lambda \
 		--output json \
 		add-layer-version-permission \
@@ -76,7 +76,7 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 		--action lambda:GetLayerVersion \
 		--principal '*' \
 		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
-		--version-number $$($(MAKE) get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
+		--version-number $$($(MAKE) -s get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 
 # Get the ARN Version for the AWS_REGIONS
 # NOTE: jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" fails in the CI

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -58,7 +58,7 @@ publish-in-all-aws-regions: validate-layer-name get-all-aws-regions
 
 # Publish the given LAYER in the given AWS region
 publish: validate-layer-name validate-aws-default-region
-	aws lambda \
+	@aws lambda \
 		--output json \
 		publish-layer-version \
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
@@ -68,7 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	echo "$$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
+	@echo "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
 	aws lambda \
 		--output json \
 		add-layer-version-permission \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -68,7 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) -s get-version)"
+	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) -s --no-print-directory get-version)"
 	@aws lambda \
 		--output json \
 		add-layer-version-permission \
@@ -76,7 +76,7 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 		--action lambda:GetLayerVersion \
 		--principal '*' \
 		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
-		--version-number $$($(MAKE) -s get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
+		--version-number $$($(MAKE) -s --no-print-directory get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 
 # Get the ARN Version for the AWS_REGIONS
 # NOTE: jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" fails in the CI

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -68,6 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
+	echo "$$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
 	aws lambda \
 		--output json \
 		add-layer-version-permission \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -72,7 +72,7 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 	aws lambda \
 		--output json \
 		add-layer-version-permission \
-		--layer-name "$(ELASTIC_LAYER_NAME)" \
+		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
 		--action lambda:GetLayerVersion \
 		--principal '*' \
 		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -68,7 +68,9 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	@echo "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
+	@echo "[debug] publish-layer-version generated $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)"
+	@ls -ltrh $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)
+	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
 	aws lambda \
 		--output json \
 		add-layer-version-permission \

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -79,9 +79,9 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 		--version-number $$($(MAKE) get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 
 # Get the ARN Version for the AWS_REGIONS
+# NOTE: jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" fails in the CI
+#       with 'parse error: Invalid numeric literal at line 1, column 5'
 get-version: validate-aws-default-region
-	# Alternative to jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)"
-	# it fails in the CI with 'parse error: Invalid numeric literal at line 1, column 5'
 	@grep '"Version"' "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" | cut -d":" -f2 | sed 's/ //g' | cut -d"," -f1
 
 # Generate the file with the ARN entries

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -68,9 +68,7 @@ publish: validate-layer-name validate-aws-default-region
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
-	@echo "[debug] publish-layer-version generated $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)"
-	@ls -ltrh $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)
-	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION))"
+	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) get-version)"
 	aws lambda \
 		--output json \
 		add-layer-version-permission \
@@ -79,6 +77,13 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 		--principal '*' \
 		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
 		--version-number $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
+		--version-number $$($(MAKE) get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
+
+# Get the ARN Version for the AWS_REGIONS
+get-version: validate-aws-default-region
+	# Alternative to jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)"
+	# it fails in the CI with 'parse error: Invalid numeric literal at line 1, column 5'
+	@grep '"Version"' "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" | cut -d":" -f2 | sed 's/ //g' | cut -d"," -f1
 
 # Generate the file with the ARN entries
 create-arn-file: validate-suffix-arn-file

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -76,7 +76,6 @@ grant-public-layer-access: validate-layer-name validate-aws-default-region
 		--action lambda:GetLayerVersion \
 		--principal '*' \
 		--statement-id "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
-		--version-number $$(jq -r .Version $(AWS_FOLDER)/$(AWS_DEFAULT_REGION)) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 		--version-number $$($(MAKE) get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
 
 # Get the ARN Version for the AWS_REGIONS


### PR DESCRIPTION
### What

Add debug traces.
Fix issue in the CI when using `jq -r '.Version' <file>` which fails with

```
'parse error: Invalid numeric literal at line 1, column 5'
```

### Test

```
AWS_ACCESS_KEY_ID=\
AWS_SECRET_ACCESS_KEY=\
AWS_DEFAULT_REGION=us-west-2 \                
ELASTIC_LAYER_NAME=v1v-aws-lambda-test \            
make publish-in-all-aws-regions
publish 'v1v-aws-lambda-test-x86_64' in af-south-1
[debug] v1v-aws-lambda-test-x86_64 with version: 19
publish 'v1v-aws-lambda-test-x86_64' in eu-north-1
[debug] v1v-aws-lambda-test-x86_64 with version: 19
...
```

### Further details

I cannot reproduce the error locally when parsing the json file with `jq`

```
[2022-02-04T12:27:07.386Z] publish 'elastic-apm-extension-ver0-0-3-arm64' in af-south-1
[2022-02-04T12:27:14.485Z] make[1]: Entering directory '/var/lib/jenkins/workspace/ibrary_apm-aws-lambda-mbp_v0.0.3/src/github.com/elastic/apm-aws-lambda/apm-lambda-extension'
[2022-02-04T12:27:14.485Z] parse error: Invalid numeric literal at line 1, column 5
[2022-02-04T12:27:15.257Z] 
[2022-02-04T12:27:15.257Z] usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
[2022-02-04T12:27:15.257Z] To see help text, you can run:
[2022-02-04T12:27:15.257Z] 
[2022-02-04T12:27:15.257Z]   aws help
[2022-02-04T12:27:15.257Z]   aws <command> help
[2022-02-04T12:27:15.257Z]   aws <command> <subcommand> help
[2022-02-04T12:27:15.257Z] 
[2022-02-04T12:27:15.257Z] aws: error: argument --version-number: expected one argument
```

