### PR TITLE
chore: set compatible architecture for published extension layers

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -64,6 +64,7 @@ publish: validate-layer-name validate-aws-default-region
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
 		--description "AWS Lambda Extension Layer for Elastic APM $(ARCHITECTURE)" \
 		--license "Apache-2.0" \
+		--compatible-architectures "$(ARCHITECTURE)"
 		--zip-file "fileb://./bin/extension.zip"
 
 # Grant public access to the given LAYER in the given AWS region


### PR DESCRIPTION
Closes: #141 

# Checklist

- [ ] Test this (see test note at https://github.com/elastic/apm-aws-lambda/pull/116)