### PR TITLE
Re-remove compatible-architectures setting as it's not supported in af-south-1

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -64,7 +64,6 @@ publish: validate-layer-name validate-aws-default-region
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
 		--description "AWS Lambda Extension Layer for Elastic APM $(ARCHITECTURE)" \
 		--license "Apache-2.0" \
-		--compatible-architectures "$(ARCHITECTURE)" \
 		--zip-file "fileb://./bin/extension.zip"
 
 # Grant public access to the given LAYER in the given AWS region


### PR DESCRIPTION
af-south-1 doesn't support `compatible-architectures`. 
We encountered this error before so removed it in https://github.com/elastic/apm-aws-lambda/pull/112
But then we erroneously added it back in https://github.com/elastic/apm-aws-lambda/issues/141
We then get this error when trying to publish the ARNs `CompatibleArchitectures are not supported in af-south-1.`

This PR removes the `compatible-architectures` option again.