### PR TITLE
Add backoff mechanism to recover from APM Server transport failures

### DIFF
--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -100,12 +100,7 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 				ContentEncoding: r.Header.Get("Content-Encoding"),
 			}
 
-			select {
-			case agentDataChan <- agentData:
-				log.Println("Adding agent data to buffer to be sent to apm server")
-			default:
-				log.Println("Channel full: dropping event")
-			}
+			EnqueueAPMData(agentDataChan, agentData)
 		}
 
 		if len(r.URL.Query()["flushed"]) > 0 && r.URL.Query()["flushed"][0] == "true" {


### PR DESCRIPTION
### Motivation / Summary
This PR aims to implement a backoff mechanism to recover from APM Server transport failures, due to the APM server being unavailable. To meet this goal, the mechanism described in issue #131 is implemented.

### Changes
In `apm_server.go`, a simple finiste state machine is implemented. The states are as follows : 
- `nominal` : in this state, the extension is able to send APM data without any issue.
- `failure` : we enter this state upon detection of a transport error. In this state, no data is sent to the APM server (the data is queued back into the dedicated channel).
- `waitingForNextAttempt` : upon detection of a transport error, a timer (defined according to the APM Transport [spec](https://github.com/elastic/apm/blob/main/specs/agents/transport.md#transport-errors)) is started. When it ends, this state is used to signal to the extension that it can try again to send data to the APM server.#147 

### Pending questions
- [ ] When should we stop trying to reconnect to the APM server ? How can we relate this mechanism to the `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS` config option.