### PR TITLE
Remove trailing newlines from log messages

### DIFF
--- a/apm-lambda-extension/extension/apm_server.go
+++ b/apm-lambda-extension/extension/apm_server.go
@@ -84,7 +84,7 @@ func PostToApmServer(client *http.Client, agentData AgentData, config *extension
 		return fmt.Errorf("failed to read the response body after posting to the APM server")
 	}
 
-	Log.Debugf("APM server response body: %v\n", string(body))
-	Log.Debugf("APM server response status code: %v\n", resp.StatusCode)
+	Log.Debugf("APM server response body: %v", string(body))
+	Log.Debugf("APM server response status code: %v", resp.StatusCode)
 	return nil
 }

--- a/apm-lambda-extension/extension/process_env.go
+++ b/apm-lambda-extension/extension/process_env.go
@@ -68,13 +68,13 @@ func ProcessEnv() *extensionConfig {
 	dataReceiverTimeoutSeconds, err := getIntFromEnv("ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS")
 	if err != nil {
 		dataReceiverTimeoutSeconds = defaultDataReceiverTimeoutSeconds
-		Log.Warnf("Could not read ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS, defaulting to %d: %v\n", dataReceiverTimeoutSeconds, err)
+		Log.Warnf("Could not read ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS, defaulting to %d: %v", dataReceiverTimeoutSeconds, err)
 	}
 
 	dataForwarderTimeoutSeconds, err := getIntFromEnv("ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS")
 	if err != nil {
 		dataForwarderTimeoutSeconds = defaultDataForwarderTimeoutSeconds
-		Log.Warnf("Could not read ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS, defaulting to %d: %v\n", dataForwarderTimeoutSeconds, err)
+		Log.Warnf("Could not read ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS, defaulting to %d: %v", dataForwarderTimeoutSeconds, err)
 	}
 
 	// add trailing slash to server name if missing
@@ -86,7 +86,7 @@ func ProcessEnv() *extensionConfig {
 	logLevel, err := logrus.ParseLevel(os.Getenv("ELASTIC_APM_LOG_LEVEL"))
 	if err != nil {
 		logLevel = logrus.InfoLevel
-		Log.Warnf("Could not read ELASTIC_APM_LOG_LEVEL, defaulting to %s: %v\n", logLevel, err)
+		Log.Warnf("Could not read ELASTIC_APM_LOG_LEVEL, defaulting to %s: %v", logLevel, err)
 	}
 
 	// Get the send strategy, convert to lowercase

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -88,7 +88,7 @@ func handleIntakeV2Events(agentDataChan chan AgentData) func(w http.ResponseWrit
 		rawBytes, err := ioutil.ReadAll(r.Body)
 		defer r.Body.Close()
 		if err != nil {
-			Log.Errorf("Could not read agent intake request body: %v\n", err)
+			Log.Errorf("Could not read agent intake request body: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}

--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -61,7 +61,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	extension.Log.Debugf("Register response: %v\n", extension.PrettyPrint(res))
+	extension.Log.Debugf("Register response: %v", extension.PrettyPrint(res))
 
 	// Create a channel to buffer apm agent data
 	agentDataChannel := make(chan extension.AgentData, 100)
@@ -106,7 +106,7 @@ func main() {
 				return
 			}
 			extension.Log.Debug("Received event.")
-			extension.Log.Debugf("%v\n", extension.PrettyPrint(event))
+			extension.Log.Debugf("%v", extension.PrettyPrint(event))
 
 			// Make a channel for signaling that we received the agent flushed signal
 			extension.AgentDoneSignal = make(chan struct{})
@@ -156,7 +156,7 @@ func main() {
 						extension.Log.Debug("Received signal that function has completed, not processing any more log events")
 						return
 					case logEvent := <-logsChannel:
-						extension.Log.Debugf("Received log event %v\n", logEvent.Type)
+						extension.Log.Debugf("Received log event %v", logEvent.Type)
 						// Check the logEvent for runtimeDone and compare the RequestID
 						// to the id that came in via the Next API
 						if logEvent.Type == logsapi.RuntimeDone {


### PR DESCRIPTION
### Motivation / Summary
Following the merge PR #147, trailing newlines in log messages are no longer necessary. This pull request resolves issue #149.