### PR TITLE
Retrieve APM Server info with a reverse proxy

### DIFF
--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -18,9 +18,10 @@
 package extension
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
+	"net/url"
 )
 
 type AgentData struct {
@@ -33,51 +34,21 @@ var AgentDoneSignal chan struct{}
 // URL: http://server/
 func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		client := &http.Client{}
 
-		req, err := http.NewRequest(r.Method, apmServerUrl, nil)
+		// Init reverse proxy
+		parsedApmServerUrl, err := url.Parse(apmServerUrl)
 		if err != nil {
-			Log.Errorf("could not create request object for %s:%s: %v", r.Method, apmServerUrl, err)
-			w.WriteHeader(http.StatusInternalServerError)
+			Log.Errorf("could not parse APM server URL: %v", err)
 			return
 		}
+		reverseProxy := httputil.NewSingleHostReverseProxy(parsedApmServerUrl)
 
-		//forward every header received
-		for name, values := range r.Header {
-			// Loop over all values for the name.
-			for _, value := range values {
-				req.Header.Set(name, value)
-			}
-		}
+		// Process request (the Golang doc suggests removing pre-existing any pre-existing X-Forwarded-For header coming
+		// from the client or an untrusted proxy to prevent IP spoofing : https://pkg.go.dev/net/http/httputil#ReverseProxy
+		r.Header.Del("X-Forwarded-For")
 
-		// Send request to apm server
-		serverResp, err := client.Do(req)
-		if err != nil {
-			Log.Errorf("error forwarding info request (`/`) to APM Server: %v", err)
-			return
-		}
-		defer serverResp.Body.Close()
-
-		// If WriteHeader is not called explicitly, the first call to Write
-		// will trigger an implicit WriteHeader(http.StatusOK).
-		if serverResp.StatusCode != 200 {
-			w.WriteHeader(serverResp.StatusCode)
-		}
-
-		// send every header received
-		for name, values := range serverResp.Header {
-			// Loop over all values for the name.
-			for _, value := range values {
-				w.Header().Add(name, value)
-			}
-		}
-
-		// copy body to request sent back to the agent
-		_, err = io.Copy(w, serverResp.Body)
-		if err != nil {
-			Log.Errorf("could not read info request response to APM Server: %v", err)
-			return
-		}
+		// Forward request to the APM server
+		reverseProxy.ServeHTTP(w, r)
 	}
 }
 

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -47,6 +47,12 @@ func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.
 		// from the client or an untrusted proxy to prevent IP spoofing : https://pkg.go.dev/net/http/httputil#ReverseProxy
 		r.Header.Del("X-Forwarded-For")
 
+		// Update headers to allow for SSL redirection
+		r.URL.Host = parsedApmServerUrl.Host
+		r.URL.Scheme = parsedApmServerUrl.Scheme
+		r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
+		r.Host = parsedApmServerUrl.Host
+
 		// Forward request to the APM server
 		reverseProxy.ServeHTTP(w, r)
 	}

--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -43,7 +43,7 @@ func handleInfoRequest(apmServerUrl string) func(w http.ResponseWriter, r *http.
 		}
 		reverseProxy := httputil.NewSingleHostReverseProxy(parsedApmServerUrl)
 
-		// Process request (the Golang doc suggests removing pre-existing any pre-existing X-Forwarded-For header coming
+		// Process request (the Golang doc suggests removing any pre-existing X-Forwarded-For header coming
 		// from the client or an untrusted proxy to prevent IP spoofing : https://pkg.go.dev/net/http/httputil#ReverseProxy
 		r.Header.Del("X-Forwarded-For")
 


### PR DESCRIPTION
### Motivation / Summary
This pull request aims to implement the changes suggested as part of the high-level code review performed in #124. It replaces the manual forwarding of the APM agent's request for APM server info by a reverse proxy-based implementation. Go's [ReverseProxy](https://pkg.go.dev/net/http/httputil#ReverseProxy) implements the desired behavior out of the box.

Resolves #138

### Validation
This PR passes all pre-existing unit-tests. 
Testing on a real Lambda function with the Python agent also shows that APM server info is successfully fetched :
```
x-amd64	State: Ready	Events: [INVOKE,SHUTDOWN]
{"@timestamp":"2022-03-22T12:16:46.559Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received event."}
{"@timestamp":"2022-03-22T12:16:46.559Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"{\n\t\"eventType\": \"INVOKE\",\n\t\"deadlineMs\": 1647951426558,\n\t\"requestId\": \"d85b1cc8-69d0-4ae1-b542-18bffa268402\",\n\t\"invokedFunctionArn\": \"arn:aws:lambda:eu-central-1:627286350134:function:lambda-sample-dev-jlvoiseux\",\n\t\"tracing\": {\n\t\t\"type\": \"X-Amzn-Trace-Id\",\n\t\t\"value\": \"Root=1-6239be2d-58c8e0f51767e95a017bbcba;Parent=3e6caf5c46d4d153;Sampled=0\"\n\t}\n}"}
{"@timestamp":"2022-03-22T12:16:46.559Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received log event platform.logsSubscription"}
[DEBUG]	2022-03-22T12:16:46.559Z	d85b1cc8-69d0-4ae1-b542-18bffa268402	flushing elasticapm
[INFO]	2022-03-22T12:16:46.580Z	d85b1cc8-69d0-4ae1-b542-18bffa268402	Fetched APM Server version 8.1.0
[DEBUG]	2022-03-22T12:16:46.581Z	d85b1cc8-69d0-4ae1-b542-18bffa268402	forced flush
{"@timestamp":"2022-03-22T12:16:46.599Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received log event platform.start"}
{"@timestamp":"2022-03-22T12:16:46.600Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received log event platform.extension"}
{"@timestamp":"2022-03-22T12:16:46.619Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Adding agent data to buffer to be sent to apm server"}
[DEBUG]	2022-03-22T12:16:46.620Z	d85b1cc8-69d0-4ae1-b542-18bffa268402	Sent request, url=http://localhost:8200/intake/v2/events size=0.55kb status=202
{"@timestamp":"2022-03-22T12:16:46.639Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Sending data chunk to APM Server"}
[DEBUG]	2022-03-22T12:16:46.640Z	d85b1cc8-69d0-4ae1-b542-18bffa268402	done flushing elasticapm
{"@timestamp":"2022-03-22T12:16:46.668Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received log event platform.runtimeDone"}
{"@timestamp":"2022-03-22T12:16:46.668Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"info","message":"Received runtimeDone event for this function invocation"}
{"@timestamp":"2022-03-22T12:16:46.668Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received runtimeDone signal"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Transport status set to healthy"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"APM server response body: "}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"APM server response status code: 202"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Received signal that function has completed, not processing any more agent data"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Flush started - Checking for agent data"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"debug","message":"Flush ended - No agent data on buffer"}
{"@timestamp":"2022-03-22T12:16:46.771Z","ecs.version":"1.6.0","event.dataset":"apm-lambda-extension","log.level":"info","message":"Waiting for next event..."}
END RequestId: d85b1cc8-69d0-4ae1-b542-18bffa268402
REPORT RequestId: d85b1cc8-69d0-4ae1-b542-18bffa268402	Duration: 213.49 ms	Billed Duration: 214 ms	Memory Size: 128 MB	Max Memory Used: 77 MB	Init Duration: 496.78 ms
``` 