### PR TITLE
Fix build.sh to not rely on default Makefile target

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -15,6 +15,9 @@ endif
 
 export AWS_FOLDER GOARCH ARCHITECTURE
 
+.PHONY: all
+all: build
+
 check-licenses:
 	go install github.com/elastic/go-licenser@v0.4.0
 	go run github.com/elastic/go-licenser@v0.4.0 -d .

--- a/apm-lambda-extension/build.sh
+++ b/apm-lambda-extension/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # build the go extension, and then zip up
-make && cd bin && zip -r extension.zip extensions
+make all && cd bin && zip -r extension.zip extensions
 
 # then run this command with amazon stuff exported
 


### PR DESCRIPTION
Before this, calling `make` would get the "check-licenses" target
instead of the "build" target it was written to use.

The recent changes for linting and license headers added new Makefile targets to the *top*, which accidentally made them the *default* Makefile target. I used "all" here as the default target because that is an old custom for \*nix-y projects that typically were built and installed via `./configure && make && make install` -- at least in my experience.