### PR TITLE
Force GO111MODULE=on in the makefile

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -2,6 +2,8 @@ SHELL = /bin/bash -eo pipefail
 
 AWS_FOLDER = .aws
 
+GO111MODULE=on
+
 ifndef GOARCH
 	GOARCH=amd64
 endif


### PR DESCRIPTION
This PR slightly tweaks the `Makefile` to force `GO111MODULE=on`. Should resolve #163.