### PR TITLE
Bump minimum supported Go version to 1.17

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -63,7 +63,7 @@ pipeline {
           }
           axis {
             name 'GO_VERSION'
-            values '1.15', '1.16', '1.17'
+            values '1.17', 1.18
           }
         }
         stages {

--- a/apm-lambda-extension/go.mod
+++ b/apm-lambda-extension/go.mod
@@ -3,14 +3,21 @@ module elastic/apm-lambda-extension
 go 1.17
 
 require (
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/ecslogrus v1.0.0
+	gotest.tools v2.2.0+incompatible
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/magefile/mage v1.9.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211102192858-4dd72447c267 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
-	gotest.tools v2.2.0+incompatible
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/apm-lambda-extension/go.mod
+++ b/apm-lambda-extension/go.mod
@@ -1,6 +1,6 @@
 module elastic/apm-lambda-extension
 
-go 1.14
+go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.6 // indirect


### PR DESCRIPTION
### Motivation / Summary
The goal of this pull request is to bump the minimum Go version supported by the extension codebase to 1.17. This bump has the following perks:
- Alignment with the [APM Server](https://github.com/elastic/apm-server/blob/main/go.mod)
- Resolve #163, tied to the `check-licenses`, `update-licenses` and `lint` make targets. These targets rely on the use of `go install` outside of a module-aware context, which is only fully [possible](https://maelvls.dev/go111module-everywhere/#go-run-knows-about-version-finally) as of Go 1.17.
- Ease the implementation of the metrics, as `Unix.Milliseconds()` and `Unix.Microseconds()` are only available in Go 1.17 (see commits 577e296 and c8e23cb).

This PR aims to track the discussion / changes necessary to perform the bump. The `.Jenkinsfile` and `go.mod` have been updated in the initial commits.