### PR TITLE
Structure main_test using the Testify Suite package

### DIFF
--- a/apm-lambda-extension/main_test.go
+++ b/apm-lambda-extension/main_test.go
@@ -25,6 +25,8 @@ import (
 	"elastic/apm-lambda-extension/logsapi"
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/suite"
+	"log"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -283,193 +285,186 @@ func eventQueueGenerator(inputQueue []MockEvent, eventsChannel chan MockEvent) {
 }
 
 // TESTS
-func TestMain(m *testing.M) {
+type MainUnitTestsSuite struct {
+	suite.Suite
+	eventsChannel      chan MockEvent
+	lambdaServer       *httptest.Server
+	apmServer          *httptest.Server
+	apmServerInternals *APMServerInternals
+}
+
+func TestMainUnitTestsSuite(t *testing.T) {
+	suite.Run(t, new(MainUnitTestsSuite))
+}
+
+// This function executes before each test case
+func (suite *MainUnitTestsSuite) SetupTest() {
+	log.Println("Hey")
 	http.DefaultServeMux = new(http.ServeMux)
-	code := m.Run()
-	os.Exit(code)
+	extension.SetApmServerTransportState(extension.Healthy, context.Background())
+	suite.eventsChannel = make(chan MockEvent, 100)
+	suite.lambdaServer, suite.apmServer, suite.apmServerInternals = initMockServers(suite.eventsChannel)
 }
 
 // TestStandardEventsChain checks a nominal sequence of events (fast APM server, only one standard event)
-func TestStandardEventsChain(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestStandardEventsChain() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: TimelyResponse, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 }
 
 // TestFlush checks if the flushed param does not cause a panic or an unexpected behavior
-func TestFlush(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestFlush() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandardFlush, APMServerBehavior: TimelyResponse, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 }
 
 // TestWaitGroup checks if there is no race condition between the main waitgroups (issue #128)
-func TestWaitGroup(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestWaitGroup() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeWaitgroupsRace, APMServerBehavior: TimelyResponse, ExecutionDuration: 1, Timeout: 500},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 }
 
 // TestAPMServerDown tests that main does not panic nor runs indefinitely when the APM server is inactive.
-func TestAPMServerDown(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	apmServer.Close()
+func (suite *MainUnitTestsSuite) TestAPMServerDown() {
+	defer suite.lambdaServer.Close()
+	suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: TimelyResponse, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.False(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.False(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 }
 
 // TestAPMServerHangs tests that main does not panic nor runs indefinitely when the APM server does not respond.
-func TestAPMServerHangs(t *testing.T) {
-	extension.SetApmServerTransportState(extension.Healthy, context.Background())
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestAPMServerHangs() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: Hangs, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.False(t, strings.Contains(apmServerInternals.Data, string(Hangs)))
-	apmServerInternals.UnlockSignalChannel <- struct{}{}
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.False(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(Hangs)))
+	suite.apmServerInternals.UnlockSignalChannel <- struct{}{}
 }
 
 // TestAPMServerRecovery tests a scenario where the APM server recovers after hanging.
 // The default forwarder timeout is 3 seconds, so we wait 5 seconds until we unlock that hanging state.
 // Hence, the APM server is waked up just in time to process the TimelyResponse data frame.
-func TestAPMServerRecovery(t *testing.T) {
-	extension.SetApmServerTransportState(extension.Healthy, context.Background())
+func (suite *MainUnitTestsSuite) TestAPMServerRecovery() {
 	if err := os.Setenv("ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS", "1"); err != nil {
-		t.Fail()
+		suite.T().Fail()
 	}
 	if err := os.Setenv("ELASTIC_APM_LOG_LEVEL", "trace"); err != nil {
-		t.Fail()
+		suite.T().Fail()
 	}
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: Hangs, ExecutionDuration: 1, Timeout: 5},
 		{Type: InvokeStandard, APMServerBehavior: TimelyResponse, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
 	go func() {
 		time.Sleep(2500 * time.Millisecond) // Cannot multiply time.Second by a float
-		apmServerInternals.UnlockSignalChannel <- struct{}{}
+		suite.apmServerInternals.UnlockSignalChannel <- struct{}{}
 	}()
-	assert.NotPanics(t, main)
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(Hangs)))
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	assert.NotPanics(suite.T(), main)
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(Hangs)))
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 	if err := os.Setenv("ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS", ""); err != nil {
-		t.Fail()
+		suite.T().Fail()
 	}
 }
 
 // TestGracePeriodHangs verifies that the WaitforGracePeriod goroutine ends when main() ends.
 // This can be checked by asserting that apmTransportStatus is pending after the execution of main.
-func TestGracePeriodHangs(t *testing.T) {
+func (suite *MainUnitTestsSuite) TestGracePeriodHangs() {
 	extension.ApmServerTransportState.Status = extension.Pending
 	extension.ApmServerTransportState.ReconnectionCount = 100
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: Hangs, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
 
 	time.Sleep(100 * time.Millisecond)
-	apmServerInternals.UnlockSignalChannel <- struct{}{}
-	defer assert.Equal(t, extension.IsTransportStatusHealthyOrPending(), true)
+	suite.apmServerInternals.UnlockSignalChannel <- struct{}{}
+	defer assert.Equal(suite.T(), extension.IsTransportStatusHealthyOrPending(), true)
 }
 
 // TestAPMServerCrashesDuringExecution tests that main does not panic nor runs indefinitely when the APM server crashes
 // during execution.
-func TestAPMServerCrashesDuringExecution(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 100)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestAPMServerCrashesDuringExecution() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: Crashes, ExecutionDuration: 1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.False(t, strings.Contains(apmServerInternals.Data, string(Crashes)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.False(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(Crashes)))
 }
 
 // TestFullChannel checks that an overload of APM data chunks is handled correctly, events dropped beyond the 100th one
 // if no space left in channel, no panic, no infinite hanging.
-func TestFullChannel(t *testing.T) {
-	eventsChannel := make(chan MockEvent, 1000)
-	lambdaServer, apmServer, apmServerInternals := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+func (suite *MainUnitTestsSuite) TestFullChannel() {
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeMultipleTransactionsOverload, APMServerBehavior: TimelyResponse, ExecutionDuration: 0.1, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
-	assert.True(t, strings.Contains(apmServerInternals.Data, string(TimelyResponse)))
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
+	assert.True(suite.T(), strings.Contains(suite.apmServerInternals.Data, string(TimelyResponse)))
 }
 
 // TestFullChannelSlowAPMServer tests what happens when the APM Data channel is full and the APM server is slow
 // (send strategy : background)
-func TestFullChannelSlowAPMServer(t *testing.T) {
+func (suite *MainUnitTestsSuite) TestFullChannelSlowAPMServer() {
 	if err := os.Setenv("ELASTIC_APM_SEND_STRATEGY", "background"); err != nil {
-		t.Fail()
+		suite.T().Fail()
 	}
-	eventsChannel := make(chan MockEvent, 1000)
-	lambdaServer, apmServer, _ := initMockServers(eventsChannel)
-	defer lambdaServer.Close()
-	defer apmServer.Close()
+	defer suite.lambdaServer.Close()
+	defer suite.apmServer.Close()
 
 	eventsChain := []MockEvent{
 		{Type: InvokeMultipleTransactionsOverload, APMServerBehavior: SlowResponse, ExecutionDuration: 0.01, Timeout: 5},
 	}
-	eventQueueGenerator(eventsChain, eventsChannel)
-	assert.NotPanics(t, main)
+	eventQueueGenerator(eventsChain, suite.eventsChannel)
+	assert.NotPanics(suite.T(), main)
 	// The test should not hang
 	if err := os.Setenv("ELASTIC_APM_SEND_STRATEGY", "syncflush"); err != nil {
-		t.Fail()
+		suite.T().Fail()
 	}
 }


### PR DESCRIPTION
### Motivation / Summary
While the addition of unit tests for `main.go` have been very useful to implement the backoff mechanism (#148) and assess the behaviour of the extension in several edge cases (#136), reliance on package-scoped state variables such as `ApmServerTransportState` induces hard-to-detect race conditions. 

An example is the commit c6b3fb5, whose CI pipeline failed due to a [race](https://apm-ci.elastic.co/job/library/job/apm-aws-lambda-mbp/job/main/78/console) between the goroutine tasked with setting the `ApmServerTransportState` back to `pending` and the start of `TestFullChannel`. The latter started before the goroutine completed its execution, and none of the events that we supposed to be queued during the test were sent to the APM Server. The issue did not appear in the many [commits](https://github.com/elastic/apm-aws-lambda/commits/main) merged beforehand, with the very same test setup.

In an attempt to prevent those races, this PR refactors `main_test.go` by using the [`suite` package of testify](https://pkg.go.dev/github.com/stretchr/testify/suite). This package allows for the definition of a `SetupTest()` function, that we can use to reset useful variables before each test, hence greatly reducing the risks of unexpected behavior.

### Files changed
All changes are contained in `main_test.go`.

### How to test
- Clone the repository
- Go to the extension folder: `cd apm-lambda-extension`
- Run the unit tests: `go test ./...`. All tests should pass (with the exception of `e2e_test`, which should be skipped).
```
ok      elastic/apm-lambda-extension    21.122s
ok      elastic/apm-lambda-extension/e2e-testing        0.463s
ok      elastic/apm-lambda-extension/extension  2.880s
ok      elastic/apm-lambda-extension/logsapi    0.625s
```