### PR TITLE
Update monitoring-aws-lambda.asciidoc

### DIFF
--- a/docs/monitoring-aws-lambda.asciidoc
+++ b/docs/monitoring-aws-lambda.asciidoc
@@ -191,4 +191,9 @@ though it ensures that all APM data is sent to the APM server.
 [role="exclude",id="aws-lambda-arch"]
 == AWS Lambda architecture
 
-Please see <<aws-lambda-arch>> instead. This link will be fixed soon.
+Please see <<aws-lambda-extension>> instead. This link will be fixed soon.
+
+[role="exclude",id="monitoring-aws-lambda"]
+== AWS Lambda architecture
+
+Please see <<aws-lambda-extension>> instead. This link will be fixed soon.

--- a/docs/monitoring-aws-lambda.asciidoc
+++ b/docs/monitoring-aws-lambda.asciidoc
@@ -194,6 +194,6 @@ though it ensures that all APM data is sent to the APM server.
 Please see <<aws-lambda-extension>> instead. This link will be fixed soon.
 
 [role="exclude",id="monitoring-aws-lambda"]
-== AWS Lambda architecture
+== Monitoring AWS Lambda
 
 Please see <<aws-lambda-extension>> instead. This link will be fixed soon.


### PR DESCRIPTION
Adds another temporary link `id`. This will be removed in https://github.com/elastic/apm-aws-lambda/pull/176.