### PR TITLE
Stop queueing back data chunks after transport failures

### DIFF
--- a/apm-lambda-extension/main.go
+++ b/apm-lambda-extension/main.go
@@ -157,7 +157,6 @@ func main() {
 					case agentData := <-agentDataChannel:
 						if err := extension.PostToApmServer(client, agentData, config, ctx); err != nil {
 							extension.Log.Errorf("Error sending to APM server, skipping: %v", err)
-							extension.EnqueueAPMData(agentDataChannel, agentData)
 							return
 						}
 					}


### PR DESCRIPTION
Resolves #187 by implementing the suggested behavior.