### PR TITLE
Clone Default Transport to configure info request reverse proxy

### DIFF
--- a/apm-lambda-extension/extension/route_handlers.go
+++ b/apm-lambda-extension/extension/route_handlers.go
@@ -51,8 +51,9 @@ func handleInfoRequest(ctx context.Context, apmServerUrl string, config *extensi
 		reverseProxy := httputil.NewSingleHostReverseProxy(parsedApmServerUrl)
 
 		reverseProxyTimeout := time.Duration(config.DataForwarderTimeoutSeconds) * time.Second
-		reverseProxy.Transport = http.DefaultTransport
-		reverseProxy.Transport.(*http.Transport).ResponseHeaderTimeout = reverseProxyTimeout
+		customTransport := http.DefaultTransport.(*http.Transport).Clone()
+		customTransport.ResponseHeaderTimeout = reverseProxyTimeout
+		reverseProxy.Transport = customTransport
 
 		reverseProxy.ErrorHandler = reverseProxyErrorHandler
 


### PR DESCRIPTION
The goal of this hotfix to correct a regression introduced by #182.
`http.defaultTransport` was used as is and not cloned, which caused segmentation violations during final tests.