### PR TITLE
Update license headers for java, js, python

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -24,10 +24,12 @@ all: build
 check-licenses:
 	go install github.com/elastic/go-licenser@v0.4.0
 	go run github.com/elastic/go-licenser@v0.4.0 -d .
+	go run github.com/elastic/go-licenser@v0.4.0 -d -ext .java .
 
 update-licenses:
 	go install github.com/elastic/go-licenser@v0.4.0
 	go run github.com/elastic/go-licenser@v0.4.0 .
+	go run github.com/elastic/go-licenser@v0.4.0 -ext .java .
 
 lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -25,11 +25,13 @@ check-licenses:
 	go install github.com/elastic/go-licenser@v0.4.0
 	go run github.com/elastic/go-licenser@v0.4.0 -d .
 	go run github.com/elastic/go-licenser@v0.4.0 -d -ext .java .
+	go run github.com/elastic/go-licenser@v0.4.0 -d -ext .js .
 
 update-licenses:
 	go install github.com/elastic/go-licenser@v0.4.0
 	go run github.com/elastic/go-licenser@v0.4.0 .
 	go run github.com/elastic/go-licenser@v0.4.0 -ext .java .
+	go run github.com/elastic/go-licenser@v0.4.0 -ext .js .
 
 lint:
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0

--- a/apm-lambda-extension/cli/.eslintrc.js
+++ b/apm-lambda-extension/cli/.eslintrc.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 module.exports = {
   env: {
     browser: true,

--- a/apm-lambda-extension/cli/build-and-publish.js
+++ b/apm-lambda-extension/cli/build-and-publish.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/elastic-lambda.js
+++ b/apm-lambda-extension/cli/elastic-lambda.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // Licensed to Elasticsearch B.V. under one or more contributor
 // license agreements. See the NOTICE file distributed with
 // this work for additional information regarding copyright
@@ -7,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/install.js
+++ b/apm-lambda-extension/cli/install.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/profile.js
+++ b/apm-lambda-extension/cli/profile.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 'use strict'
 const yaml = require('js-yaml')
 const AWS = require('aws-sdk')

--- a/apm-lambda-extension/cli/profile/code/index.js
+++ b/apm-lambda-extension/cli/profile/code/index.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 exports.handler = async (event) => {
   const response = {
     statuscode: 200,

--- a/apm-lambda-extension/cli/profile/elasticagent/index.js
+++ b/apm-lambda-extension/cli/profile/elasticagent/index.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 const apm = require('elastic-apm-node').start({})
 exports.handler = apm.lambda(function handler (event, context, callback) {
   return new Promise(function (resolve, reject) {

--- a/apm-lambda-extension/cli/profile/noagent/index.js
+++ b/apm-lambda-extension/cli/profile/noagent/index.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 exports.handler = async (event) => {
   const response = {
     statuscode: 200,

--- a/apm-lambda-extension/cli/tests/build-and-publish.test.js
+++ b/apm-lambda-extension/cli/tests/build-and-publish.test.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/tests/profile.test.js
+++ b/apm-lambda-extension/cli/tests/profile.test.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/tests/update-layer.test.js
+++ b/apm-lambda-extension/cli/tests/update-layer.test.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/update-function-env.js
+++ b/apm-lambda-extension/cli/update-function-env.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/cli/update-layer.js
+++ b/apm-lambda-extension/cli/update-layer.js
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/apm-lambda-extension/e2e-testing/sam-java/sam-testing-java/src/main/java/samtestingjava/App.java
+++ b/apm-lambda-extension/e2e-testing/sam-java/sam-testing-java/src/main/java/samtestingjava/App.java
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package samtestingjava;
 
 import java.io.BufferedReader;

--- a/apm-lambda-extension/e2e-testing/sam-nodejs/sam-testing-nodejs/app.js
+++ b/apm-lambda-extension/e2e-testing/sam-nodejs/sam-testing-nodejs/app.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 // const url = 'http://checkip.amazonaws.com/';
 const apm = require('elastic-apm-node').start({/*...*/})
 let response;

--- a/apm-lambda-extension/e2e-testing/sam-python/sam-testing-python/app.py
+++ b/apm-lambda-extension/e2e-testing/sam-python/sam-testing-python/app.py
@@ -1,3 +1,22 @@
+#!/usr/bin/env python
+
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import json
 import os
 


### PR DESCRIPTION
Updating the Makefile to also add the license headers to the test examples written in `python`, `java` and `js`. 

* python: cannot be automated yet, due to https://github.com/elastic/go-licenser/issues/43
* java: automated
* js: adding the license header cannot be automated as the formatting would be changed, but the check can be automated and is done 
