### PR TITLE
feat: log a warning when authentication with APM server fails 

### DIFF
--- a/apm-lambda-extension/extension/apm_server_transport.go
+++ b/apm-lambda-extension/extension/apm_server_transport.go
@@ -185,10 +185,10 @@ func (transport *ApmServerTransport) PostToApmServer(ctx context.Context, agentD
 		return fmt.Errorf("failed to read the response body after posting to the APM server")
 	}
 
-	// On success, the server will respond with a 202 Accepted status code.
-	// Log a warning otherwise.
-	if resp.StatusCode != http.StatusAccepted {
-		Log.Warnf("APM server request failed with status code: %d", resp.StatusCode)
+	if resp.StatusCode == http.StatusUnauthorized {
+		Log.Warnf("Authentication with the APM server failed: response status code: %d", resp.StatusCode)
+		Log.Debugf("APM server response body: %v", string(body))
+		return nil
 	}
 
 	transport.SetApmServerTransportState(ctx, Healthy)

--- a/apm-lambda-extension/extension/apm_server_transport.go
+++ b/apm-lambda-extension/extension/apm_server_transport.go
@@ -185,6 +185,12 @@ func (transport *ApmServerTransport) PostToApmServer(ctx context.Context, agentD
 		return fmt.Errorf("failed to read the response body after posting to the APM server")
 	}
 
+	// On success, the server will respond with a 202 Accepted status code.
+	// Log a warning otherwise.
+	if resp.StatusCode != http.StatusAccepted {
+		Log.Warnf("APM server request failed with status code: %d", resp.StatusCode)
+	}
+
 	transport.SetApmServerTransportState(ctx, Healthy)
 	Log.Debug("Transport status set to healthy")
 	Log.Debugf("APM server response body: %v", string(body))

--- a/apm-lambda-extension/extension/apm_server_transport_test.go
+++ b/apm-lambda-extension/extension/apm_server_transport_test.go
@@ -60,10 +60,12 @@ func TestPostToApmServerDataCompressed(t *testing.T) {
 		bytes, _ := ioutil.ReadAll(r.Body)
 		assert.Equal(t, string(data), string(bytes))
 		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+		w.WriteHeader(http.StatusAccepted)
 		if _, err := w.Write([]byte(`{"foo": "bar"}`)); err != nil {
 			t.Fail()
 			return
 		}
+
 	}))
 	defer apmServer.Close()
 
@@ -105,6 +107,7 @@ func TestPostToApmServerDataNotCompressed(t *testing.T) {
 		compressedBytes, _ := ioutil.ReadAll(pr)
 		assert.Equal(t, string(compressedBytes), string(requestBytes))
 		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+		w.WriteHeader(http.StatusAccepted)
 		if _, err := w.Write([]byte(`{"foo": "bar"}`)); err != nil {
 			t.Fail()
 			return
@@ -334,6 +337,7 @@ func TestAPMServerRecovery(t *testing.T) {
 		bytes, _ := ioutil.ReadAll(r.Body)
 		assert.Equal(t, string(data), string(bytes))
 		assert.Equal(t, "gzip", r.Header.Get("Content-Encoding"))
+		w.WriteHeader(http.StatusAccepted)
 		if _, err := w.Write([]byte(`{"foo": "bar"}`)); err != nil {
 			return
 		}


### PR DESCRIPTION
The intake route of the APM server sends a 202 status accepted
if the request succeeds.

See https://github.com/elastic/apm-server/blob/main/docs/api-events.asciidoc#response

If auth fails the server returns a 401.

See https://github.com/elastic/apm-server/blob/3cd1a63bf218ea0ab0f240924236823e1815882b/beater/middleware/auth_middleware.go#L54-L57 and https://github.com/elastic/apm-server/blob/3cd1a63bf218ea0ab0f240924236823e1815882b/beater/request/result.go#L86


Related to https://github.com/elastic/apm-aws-lambda/issues/205+