### PR TITLE
refactor: replace pkg/errors with native go errors

### DIFF
--- a/apm-lambda-extension/NOTICE.txt
+++ b/apm-lambda-extension/NOTICE.txt
@@ -2535,6 +2535,39 @@ Contents of probable licence file $GOMODCACHE/github.com/aws/smithy-go@v1.12.0/L
 
 
 --------------------------------------------------------------------------------
+Module  : github.com/pkg/errors
+Version : v0.9.1
+Time    : 2020-01-14T19:47:44Z
+Licence : BSD-2-Clause
+
+Contents of probable licence file $GOMODCACHE/github.com/pkg/errors@v0.9.1/LICENSE:
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+--------------------------------------------------------------------------------
 Module  : go.elastic.co/apm/v2
 Version : v2.1.1-0.20220617022209-90f624fe11b0
 Time    : 2022-06-17T02:22:09Z

--- a/apm-lambda-extension/NOTICE.txt
+++ b/apm-lambda-extension/NOTICE.txt
@@ -2535,39 +2535,6 @@ Contents of probable licence file $GOMODCACHE/github.com/aws/smithy-go@v1.12.0/L
 
 
 --------------------------------------------------------------------------------
-Module  : github.com/pkg/errors
-Version : v0.9.1
-Time    : 2020-01-14T19:47:44Z
-Licence : BSD-2-Clause
-
-Contents of probable licence file $GOMODCACHE/github.com/pkg/errors@v0.9.1/LICENSE:
-
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
---------------------------------------------------------------------------------
 Module  : go.elastic.co/apm/v2
 Version : v2.1.1-0.20220617022209-90f624fe11b0
 Time    : 2022-06-17T02:22:09Z

--- a/apm-lambda-extension/extension/process_metadata.go
+++ b/apm-lambda-extension/extension/process_metadata.go
@@ -22,11 +22,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type MetadataContainer struct {
@@ -38,7 +37,7 @@ type MetadataContainer struct {
 func ProcessMetadata(data AgentData) ([]byte, error) {
 	uncompressedData, err := GetUncompressedBytes(data.Data, data.ContentEncoding)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error uncompressing agent data for metadata extraction : %v", err))
+		return nil, fmt.Errorf("Error uncompressing agent data for metadata extraction: %w", err)
 	}
 	scanner := bufio.NewScanner(strings.NewReader(string(uncompressedData)))
 	scanner.Scan()

--- a/apm-lambda-extension/go.mod
+++ b/apm-lambda-extension/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/joho/godotenv v1.4.0
 	github.com/magefile/mage v1.13.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/ecszap v1.0.1
 	go.uber.org/atomic v1.9.0 // indirect
@@ -33,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.16.9 // indirect
 	github.com/aws/smithy-go v1.12.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/apm-lambda-extension/logsapi/client.go
+++ b/apm-lambda-extension/logsapi/client.go
@@ -20,11 +20,10 @@ package logsapi
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-
-	"github.com/pkg/errors"
 )
 
 const lambdaAgentIdentifierHeaderKey string = "Lambda-Extension-Identifier"
@@ -153,7 +152,7 @@ func (c *Client) Subscribe(types []EventType, destinationURI URI, extensionId st
 			Destination:   destination,
 		})
 	if err != nil {
-		return nil, errors.WithMessage(err, "failed to marshal SubscribeRequest")
+		return nil, fmt.Errorf("failed to marshal SubscribeRequest: %w", err)
 	}
 
 	headers := make(map[string]string)
@@ -166,14 +165,14 @@ func (c *Client) Subscribe(types []EventType, destinationURI URI, extensionId st
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusAccepted {
-		return nil, errors.Errorf("Logs API is not supported in this environment")
+		return nil, errors.New("Logs API is not supported in this environment")
 	} else if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return nil, errors.Errorf("%s failed: %d[%s]", url, resp.StatusCode, resp.Status)
+			return nil, fmt.Errorf("%s failed: %d[%s]", url, resp.StatusCode, resp.Status)
 		}
 
-		return nil, errors.Errorf("%s failed: %d[%s] %s", url, resp.StatusCode, resp.Status, string(body))
+		return nil, fmt.Errorf("%s failed: %d[%s] %s", url, resp.StatusCode, resp.Status, string(body))
 	}
 
 	body, _ := ioutil.ReadAll(resp.Body)

--- a/apm-lambda-extension/logsapi/subscribe.go
+++ b/apm-lambda-extension/logsapi/subscribe.go
@@ -19,6 +19,7 @@ package logsapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,8 +27,6 @@ import (
 	"time"
 
 	"elastic/apm-lambda-extension/extension"
-
-	"github.com/pkg/errors"
 )
 
 // TODO: Remove global variable and find another way to retrieve Logs Listener network info when testing main


### PR DESCRIPTION
Go 1.13 added native errors with support for error wrapping
and additional information.

See https://go.dev/blog/go1.13-errors