### PR TITLE
docs: fix nodejs agent docker setup instructions

### DIFF
--- a/docs/lambda-selector/extension-arn-replacement.asciidoc
+++ b/docs/lambda-selector/extension-arn-replacement.asciidoc
@@ -2,6 +2,8 @@
 <script>
 window.addEventListener("DOMContentLoaded", async () => {
   addArnGenerator('extension', 'apm-aws-lambda', 'arn:aws:lambda:${region}:267093732750:layer:elastic-apm-extension-${version}-${arch}');
+  replaceAgentDockerImageParams('FROM docker.elastic.co/observability/apm-agent-nodejs:latest AS nodejs-agent',
+                                'COPY --from=nodejs-agent /opt/nodejs/ /opt/nodejs/');
 });
 </script>
 ++++


### PR DESCRIPTION
See https://www.elastic.co/guide/en/apm/agent/nodejs/current/lambda.html

Current documentation appears as:

```
FROM docker.elastic.co/observability/apm-lambda-extension-x86_64:latest AS lambda-extension
AGENT_IMPORT
 
# FROM ...  <-- this is the base image of your Lambda function
 
COPY --from=lambda-extension /opt/elastic-apm-extension /opt/extensions/elastic-apm-extension
AGENT_COPY
```
