### PR TITLE
fix: properly handle http.ErrServerClosed

### DIFF
--- a/apm-lambda-extension/extension/http_server.go
+++ b/apm-lambda-extension/extension/http_server.go
@@ -19,6 +19,7 @@ package extension
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"time"
@@ -45,12 +46,10 @@ func StartHttpServer(ctx context.Context, transport *ApmServerTransport) (agentD
 
 	go func() {
 		Log.Infof("Extension listening for apm data on %s", server.Addr)
-		if err = server.Serve(ln); err != nil {
-			if err.Error() == "http: server closed" {
-				Log.Debug(err)
-			} else {
-				Log.Errorf("Error upon APM data server start : %v", err)
-			}
+		if err = server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			Log.Errorf("Error upon APM data server start : %v", err)
+		} else {
+			Log.Debug("Server closed correctly")
 		}
 	}()
 	return server, nil

--- a/apm-lambda-extension/extension/http_server.go
+++ b/apm-lambda-extension/extension/http_server.go
@@ -47,9 +47,9 @@ func StartHttpServer(ctx context.Context, transport *ApmServerTransport) (agentD
 	go func() {
 		Log.Infof("Extension listening for apm data on %s", server.Addr)
 		if err = server.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			Log.Errorf("Error upon APM data server start : %v", err)
+			Log.Errorf("received error from http.Serve(): %v", err)
 		} else {
-			Log.Debug("Server closed correctly")
+			Log.Debug("server closed")
 		}
 	}()
 	return server, nil

--- a/apm-lambda-extension/logsapi/subscribe.go
+++ b/apm-lambda-extension/logsapi/subscribe.go
@@ -122,7 +122,7 @@ func startHTTPServer(ctx context.Context, transport *LogsTransport) error {
 
 	go func() {
 		extension.Log.Infof("Extension listening for Lambda Logs API events on %s", transport.listener.Addr().String())
-		if err = transport.server.Serve(transport.listener); err != nil {
+		if err = transport.server.Serve(transport.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			extension.Log.Errorf("Error upon Logs API server start : %v", err)
 		}
 	}()


### PR DESCRIPTION
Logs API server: the server was ignoring ErrServerClosed and logging an error.

APM Data server: the server was using an equality check with the error message but
it was never satisfied because of a typo ('server closed' vs 'Server closed'), leading
to an error message.

Both servers are now handling the error and logging a message that the server stopped
successfully. The code is using go 1.13 errors to avoid comparing strings and for better
compatibility.