### PR TITLE
fix: use 1.17 'go run' syntax in lint task

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -37,9 +37,8 @@ update-licenses:
 	go run github.com/elastic/go-licenser@v0.4.0 -ext .java .
 
 lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
-	golangci-lint --version
-	golangci-lint run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0 --version
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0 run
 
 build: check-licenses gen-notice
 	GOOS=linux go build -o bin/extensions/apm-lambda-extension main.go


### PR DESCRIPTION
make lint is failing in local environment because of a command
not found error.
It seems the command is called in the current dir but 'go install'
will install packages to GOBIN.

See https://go.dev/ref/mod#go-install

Instead of updating the path, we can use the new Go 1.17 syntax for
'go run'.

See https://tip.golang.org/doc/go1.17#go%20run