### PR TITLE
feat: add support for reproducible builds

### DIFF
--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -7,7 +7,7 @@ AGENT_VERSION = $(shell echo $${BRANCH_NAME} | cut -f 2 -d 'v')
 
 # Add support for SOURCE_DATE_EPOCH and reproducble buils
 # See https://reproducible-builds.org/specs/source-date-epoch/
-SOURCE_DATE_EPOCH ?= 0
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
 
 ifndef GOARCH
 	GOARCH=amd64

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -62,7 +62,7 @@ endif
 	$(MAKE) publish
 zip:
 	cd bin \
-	&& rm -f extension.zip || true \
+	&& rm -f extension.zip \
 	&& find extensions NOTICE.txt dependencies.asciidoc | xargs touch -d @$(SOURCE_DATE_EPOCH) \
 	&& zip -X -r extension.zip extensions NOTICE.txt dependencies.asciidoc \
 	&& cp extension.zip ${GOARCH}.zip

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -5,6 +5,10 @@ DOCKER_IMAGE_NAME = observability/apm-lambda-extension
 DOCKER_REGISTRY = docker.elastic.co
 AGENT_VERSION = $(shell echo $${BRANCH_NAME} | cut -f 2 -d 'v')
 
+# Add support for SOURCE_DATE_EPOCH and reproducble buils
+# See https://reproducible-builds.org/specs/source-date-epoch/
+SOURCE_DATE_EPOCH ?= 0
+
 ifndef GOARCH
 	GOARCH=amd64
 endif
@@ -57,7 +61,11 @@ endif
 	GOARCH=${GOARCH} make zip
 	$(MAKE) publish
 zip:
-	cd bin && rm -f extension.zip || true && zip -r extension.zip extensions NOTICE.txt dependencies.asciidoc && cp extension.zip ${GOARCH}.zip
+	cd bin \
+	&& rm -f extension.zip || true \
+	&& find extensions NOTICE.txt dependencies.asciidoc | xargs touch -d @$(SOURCE_DATE_EPOCH) \
+	&& zip -X -r extension.zip extensions NOTICE.txt dependencies.asciidoc \
+	&& cp extension.zip ${GOARCH}.zip
 test:
 	go test extension/*.go -v
 env:

--- a/apm-lambda-extension/build.sh
+++ b/apm-lambda-extension/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # build the go extension, and then zip up
-make all && cd bin && zip -r extension.zip extensions
+make all && make zip
 
 # then run this command with amazon stuff exported
 


### PR DESCRIPTION
Add support for SOURCE_DATE_EPOCH to avoid timestamp and timezones
issues.

See https://reproducible-builds.org/specs/source-date-epoch/

Make sure zip entries have a consistent mtime and strip extra
attributes.

See https://reproducible-builds.org/docs/archives/

Zip archives are now reproducible by default. Update script
to use the make task and avoid calling zip directly.

For more information see https://reproducible-builds.org/