### PR TITLE
fix: do not ignore marshal errors when handling Report log event

### DIFF
--- a/apm-lambda-extension/logsapi/process_metrics.go
+++ b/apm-lambda-extension/logsapi/process_metrics.go
@@ -99,7 +99,7 @@ func ProcessPlatformReport(ctx context.Context, metadataContainer *extension.Met
 
 	var jsonWriter fastjson.Writer
 	if err := metricsContainer.MarshalFastJSON(&jsonWriter); err != nil {
-		return extension.AgentData{Data: metricsData}, nil
+		return extension.AgentData{}, err
 	}
 
 	if metadataContainer.Metadata != nil {


### PR DESCRIPTION
Avoid sending empty metrics data and return the marshal error
instead of ignoring it.
The caller logs the error with the appropriate log level.