### PR TITLE
refactor: avoid tempdir workaround in notice script

### DIFF
--- a/apm-lambda-extension/scripts/notice.sh
+++ b/apm-lambda-extension/scripts/notice.sh
@@ -22,14 +22,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR=${SCRIPT_DIR}/..
-TEMP_DIR=$(mktemp -d)
-LICENCE_DETECTOR="go.elastic.co/go-licence-detector@v0.3.0"
-
-trap '[[ $TEMP_DIR ]] && rm -rf "$TEMP_DIR"' EXIT
-
-get_licence_detector() {
-    GOBIN="$TEMP_DIR" go install "$LICENCE_DETECTOR"
-}
 
 generate_notice() {
     (
@@ -41,7 +33,7 @@ generate_notice() {
         for pkg in $pkgs; do
           deps+="$(go list -m -json $pkg)\n"
         done
-        echo -e $deps | "${TEMP_DIR}"/go-licence-detector \
+        echo -e $deps | go run go.elastic.co/go-licence-detector@v0.3.0 \
             -depsTemplate="${SCRIPT_DIR}"/templates/dependencies.asciidoc.tmpl \
             -depsOut="${PROJECT_DIR}"/dependencies.asciidoc \
             -noticeTemplate="${SCRIPT_DIR}"/templates/NOTICE.txt.tmpl \
@@ -53,5 +45,4 @@ generate_notice() {
 }
 
 echo "Generating notice file and dependency list"
-get_licence_detector
 generate_notice


### PR DESCRIPTION
Go 1.17 added a new syntax for 'go run' to execute specific
versions without installing the binary.

See See https://tip.golang.org/doc/go1.17#go%20run

Remove the tempdir creation and removal and cleanup the notice
script.