### PR TITLE
add documentation automation

### DIFF
--- a/.github/workflows/addToDocsProject.yml
+++ b/.github/workflows/addToDocsProject.yml
@@ -1,0 +1,27 @@
+name: Add to obs-docs project
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add_to_project:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Team:Docs'
+    steps:
+      - uses: octokit/graphql-action@v2.x
+        id: add_to_project
+        with:
+          headers: '{"GraphQL-Features": "projects_next_graphql"}'
+          query: |
+            mutation add_to_project($projectid:ID!,$contentid:ID!) {
+              addProjectNextItem(input:{projectId:$projectid contentId:$contentid}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }
+          projectid: ${{ env.PROJECT_ID }}
+          contentid: ${{ github.event.issue.node_id }}
+        env:
+          PROJECT_ID: "PN_kwDOAGc3Zs0iZw"
+          GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}


### PR DESCRIPTION
This PR adds automation that automatically adds any issues labeled `Team:Docs` to the documentation planning board.

* Related to https://github.com/elastic/apm-server/pull/8608