### PR TITLE
fix: do not enqueue broken metrics data to the apm server

### DIFF
--- a/apm-lambda-extension/logsapi/event.go
+++ b/apm-lambda-extension/logsapi/event.go
@@ -93,10 +93,10 @@ func (lc *Client) ProcessLogs(
 					extension.Log.Debug("Received platform report for the previous function invocation")
 					processedMetrics, err := ProcessPlatformReport(metadataContainer, prevEvent, logEvent)
 					if err != nil {
-						extension.Log.Errorf("Error processing Lambda platform metrics : %v", err)
-					} else {
-						apmClient.EnqueueAPMData(processedMetrics)
+						return err
 					}
+
+					apmClient.EnqueueAPMData(processedMetrics)
 				} else {
 					extension.Log.Warn("report event request id didn't match the previous event id")
 					extension.Log.Debug("Log API runtimeDone event request id didn't match")


### PR DESCRIPTION
If an error is returned when processing platform metrics, the
processed metrics are enqueued to the apm server regardless.

We can't assume anything about the processed metrics so we
return an error which is logged correctly.