### PR TITLE
fix: retract version 1.0.1

### DIFF
--- a/apm-lambda-extension/go.mod
+++ b/apm-lambda-extension/go.mod
@@ -37,3 +37,5 @@ require (
 	github.com/santhosh-tekuri/jsonschema v1.2.4 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+retract v1.0.1


### PR DESCRIPTION
v1.0.1 is broken and should not be used. Add an explicit
retract directive to the go.mod.

See https://go.dev/doc/modules/gomod-ref#retract