### PR TITLE
perf: improve processmetadata performance and reduce allocations

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
           }
           axis {
             name 'GO_VERSION'
-            values '1.17', 1.18
+            values '1.18'
           }
         }
         stages {

--- a/apm-lambda-extension/apmproxy/metadata.go
+++ b/apm-lambda-extension/apmproxy/metadata.go
@@ -40,12 +40,7 @@ func ProcessMetadata(data AgentData) ([]byte, error) {
 
 	before, _, _ := bytes.Cut(uncompressedData, []byte("\n"))
 
-	// Try without lowercase first to avoid allocations.
 	if bytes.Contains(before, []byte("metadata")) {
-		return before, nil
-	}
-
-	if bytes.Contains(bytes.ToLower(before), []byte("metadata")) {
 		return before, nil
 	}
 

--- a/apm-lambda-extension/apmproxy/metadata.go
+++ b/apm-lambda-extension/apmproxy/metadata.go
@@ -18,14 +18,12 @@
 package apmproxy
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 )
 
 type MetadataContainer struct {
@@ -39,18 +37,25 @@ func ProcessMetadata(data AgentData) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error uncompressing agent data for metadata extraction: %w", err)
 	}
-	scanner := bufio.NewScanner(strings.NewReader(string(uncompressedData)))
-	scanner.Scan()
-	if strings.Contains(strings.ToLower(scanner.Text()), "metadata") {
-		return scanner.Bytes(), nil
+
+	before, _, _ := bytes.Cut(uncompressedData, []byte("\n"))
+
+	// Try without lowercase first to avoid allocations.
+	if bytes.Contains(before, []byte("metadata")) {
+		return before, nil
 	}
+
+	if bytes.Contains(bytes.ToLower(before), []byte("metadata")) {
+		return before, nil
+	}
+
 	return nil, errors.New("No metadata found in APM agent payload")
 }
 
 func GetUncompressedBytes(rawBytes []byte, encodingType string) ([]byte, error) {
 	switch encodingType {
 	case "deflate":
-		reader := bytes.NewReader([]byte(rawBytes))
+		reader := bytes.NewReader(rawBytes)
 		zlibreader, err := zlib.NewReader(reader)
 		if err != nil {
 			return nil, fmt.Errorf("could not create zlib.NewReader: %v", err)
@@ -61,7 +66,7 @@ func GetUncompressedBytes(rawBytes []byte, encodingType string) ([]byte, error) 
 		}
 		return bodyBytes, nil
 	case "gzip":
-		reader := bytes.NewReader([]byte(rawBytes))
+		reader := bytes.NewReader(rawBytes)
 		zlibreader, err := gzip.NewReader(reader)
 		if err != nil {
 			return nil, fmt.Errorf("could not create gzip.NewReader: %v", err)

--- a/apm-lambda-extension/apmproxy/metadata.go
+++ b/apm-lambda-extension/apmproxy/metadata.go
@@ -21,7 +21,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
-	"errors"
 	"fmt"
 	"io"
 )
@@ -39,12 +38,7 @@ func ProcessMetadata(data AgentData) ([]byte, error) {
 	}
 
 	before, _, _ := bytes.Cut(uncompressedData, []byte("\n"))
-
-	if bytes.Contains(before, []byte("metadata")) {
-		return before, nil
-	}
-
-	return nil, errors.New("No metadata found in APM agent payload")
+	return before, nil
 }
 
 func GetUncompressedBytes(rawBytes []byte, encodingType string) ([]byte, error) {

--- a/apm-lambda-extension/apmproxy/metadata_test.go
+++ b/apm-lambda-extension/apmproxy/metadata_test.go
@@ -74,7 +74,7 @@ func BenchmarkProcessMetadata(b *testing.B) {
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				apmproxy.ProcessMetadata(agentData)
+				_, _ = apmproxy.ProcessMetadata(agentData)
 			}
 		})
 	}

--- a/apm-lambda-extension/apmproxy/metadata_test.go
+++ b/apm-lambda-extension/apmproxy/metadata_test.go
@@ -49,3 +49,33 @@ func Test_processMetadata(t *testing.T) {
 
 	assert.JSONEq(t, string(desiredMetadata), string(extractedMetadata))
 }
+
+func BenchmarkProcessMetadata(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "simple",
+			// Copied from https://github.com/elastic/apm-server/blob/master/testdata/intake-v2/transactions.ndjson.
+			body: []byte(`{"metadata": {"service": {"name": "1234_service-12a3","node": {"configured_name": "node-123"},"version": "5.1.3","environment": "staging","language": {"name": "ecmascript","version": "8"},"runtime": {"name": "node","version": "8.0.0"},"framework": {"name": "Express","version": "1.2.3"},"agent": {"name": "elastic-node","version": "3.14.0"}},"user": {"id": "123user", "username": "bar", "email": "bar@user.com"}, "labels": {"tag0": null, "tag1": "one", "tag2": 2}, "process": {"pid": 1234,"ppid": 6789,"title": "node","argv": ["node","server.js"]},"system": {"hostname": "prod1.example.com","architecture": "x64","platform": "darwin", "container": {"id": "container-id"}, "kubernetes": {"namespace": "namespace1", "pod": {"uid": "pod-uid", "name": "pod-name"}, "node": {"name": "node-name"}}},"cloud":{"account":{"id":"account_id","name":"account_name"},"availability_zone":"cloud_availability_zone","instance":{"id":"instance_id","name":"instance_name"},"machine":{"type":"machine_type"},"project":{"id":"project_id","name":"project_name"},"provider":"cloud_provider","region":"cloud_region","service":{"name":"lambda"}}}}
+{"transaction": { "id": "945254c567a5417e", "trace_id": "0123456789abcdef0123456789abcdef", "parent_id": "abcdefabcdef01234567", "type": "request", "duration": 32.592981,  "span_count": { "started": 43 }}}
+{"transaction": {"id": "4340a8e0df1906ecbfa9", "trace_id": "0acd456789abcdef0123456789abcdef", "name": "GET /api/types","type": "request","duration": 32.592981,"outcome":"success", "result": "success", "timestamp": 1496170407154000, "sampled": true, "span_count": {"started": 17},"context": {"service": {"runtime": {"version": "7.0"}},"page":{"referer":"http://localhost:8000/test/e2e/","url":"http://localhost:8000/test/e2e/general-usecase/"}, "request": {"socket": {"remote_address": "12.53.12.1","encrypted": true},"http_version": "1.1","method": "POST","url": {"protocol": "https:","full": "https://www.example.com/p/a/t/h?query=string#hash","hostname": "www.example.com","port": "8080","pathname": "/p/a/t/h","search": "?query=string","hash": "#hash","raw": "/p/a/t/h?query=string#hash"},"headers": {"user-agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","Mozilla Chrome Edge"],"content-type": "text/html","cookie": "c1=v1, c2=v2","some-other-header": "foo","array": ["foo","bar","baz"]},"cookies": {"c1": "v1","c2": "v2"},"env": {"SERVER_SOFTWARE": "nginx","GATEWAY_INTERFACE": "CGI/1.1"},"body": {"str": "hello world","additional": { "foo": {},"bar": 123,"req": "additional information"}}},"response": {"status_code": 200,"headers": {"content-type": "application/json"},"headers_sent": true,"finished": true,"transfer_size":25.8,"encoded_body_size":26.90,"decoded_body_size":29.90}, "user": {"domain": "ldap://abc","id": "99","username": "foo"},"tags": {"organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8", "tag2": 12, "tag3": 12.45, "tag4": false, "tag5": null },"custom": {"my_key": 1,"some_other_value": "foo bar","and_objects": {"foo": ["bar","baz"]},"(": "not a valid regex and that is fine"}}}}
+{"transaction": { "id": "cdef4340a8e0df19", "trace_id": "0acd456789abcdef0123456789abcdef", "type": "request", "duration": 13.980558, "timestamp": 1532976822281000, "sampled": null, "span_count": { "dropped": 55, "started": 436 }, "marks": {"navigationTiming": {"appBeforeBootstrap": 608.9300000000001,"navigationStart": -21},"another_mark": {"some_long": 10,"some_float": 10.0}, "performance": {}}, "context": { "request": { "socket": { "remote_address": "192.0.1", "encrypted": null }, "method": "POST", "headers": { "user-agent": null, "content-type": null, "cookie": null }, "url": { "protocol": null, "full": null, "hostname": null, "port": null, "pathname": null, "search": null, "hash": null, "raw": null } }, "response": { "headers": { "content-type": null } }, "service": {"environment":"testing","name": "service1","node": {"configured_name": "node-ABC"}, "language": {"version": "2.5", "name": "ruby"}, "agent": {"version": "2.2", "name": "elastic-ruby", "ephemeral_id": "justanid"}, "framework": {"version": "5.0", "name": "Rails"}, "version": "2", "runtime": {"version": "2.5", "name": "cruby"}}},"experience":{"cls":1,"fid":2.0,"tbt":3.4,"longtask":{"count":3,"sum":2.5,"max":1}}}}
+{"transaction": { "id": "00xxxxFFaaaa1234", "trace_id": "0123456789abcdef0123456789abcdef", "name": "amqp receive", "parent_id": "abcdefabcdef01234567", "type": "messaging", "duration": 3, "span_count": { "started": 1 }, "context": {"message": {"queue": { "name": "new_users"}, "age":{ "ms": 1577958057123}, "headers": {"user_id": "1ax3", "involved_services": ["user", "auth"]}, "body": "user created", "routing_key": "user-created-transaction"}},"session":{"id":"sunday","sequence":123}}}
+{"transaction": { "name": "july-2021-delete-after-july-31", "type": "lambda", "result": "success", "id": "142e61450efb8574", "trace_id": "eb56529a1f461c5e7e2f66ecb075e983", "subtype": null, "action": null, "duration": 38.853, "timestamp": 1631736666365048, "sampled": true, "context": { "cloud": { "origin": { "account": { "id": "abc123" }, "provider": "aws", "region": "us-east-1", "service": { "name": "serviceName" } } }, "service": { "origin": { "id": "abc123", "name": "service-name", "version": "1.0" } }, "user": {}, "tags": {}, "custom": { } }, "sync": true, "span_count": { "started": 0 }, "outcome": "unknown", "faas": { "coldstart": false, "execution": "2e13b309-23e1-417f-8bf7-074fc96bc683", "trigger": { "request_id": "FuH2Cir_vHcEMUA=", "type": "http" } }, "sample_rate": 1 } }
+`),
+		},
+	}
+
+	for _, bench := range benchmarks {
+		agentData := apmproxy.AgentData{Data: bench.body, ContentEncoding: ""}
+
+		b.Run(bench.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				apmproxy.ProcessMetadata(agentData)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Avoid copying byte slices and make ProcessMetadata zero-allocation.
Add a benchmark to reproduce the numbers:

```
name                       old time/op    new time/op    delta
ProcessMetadata/simple-16    7.89µs ± 8%    0.04µs ± 3%   -99.52%  (p=0.000 n=10+10)

name                       old alloc/op   new alloc/op   delta
ProcessMetadata/simple-16    12.6kB ± 0%     0.0kB       -100.00%  (p=0.000 n=10+10)

name                       old allocs/op  new allocs/op  delta
ProcessMetadata/simple-16      5.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```