### PR TITLE
refactor: remove deprecated ioutil references

### DIFF
--- a/apm-lambda-extension/e2e-testing/e2e_test.go
+++ b/apm-lambda-extension/e2e-testing/e2e_test.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -163,7 +162,7 @@ func retrieveJavaAgent(samJavaPath string, version string) {
 func changeJavaAgentPermissions(samJavaPath string) {
 	agentFolderPath := filepath.Join(samJavaPath, "agent")
 	extension.Log.Info("Setting appropriate permissions for Java agent files...")
-	agentFiles, err := ioutil.ReadDir(agentFolderPath)
+	agentFiles, err := os.ReadDir(agentFolderPath)
 	ProcessError(err)
 	for _, f := range agentFiles {
 		if err = os.Chmod(filepath.Join(agentFolderPath, f.Name()), 0755); err != nil {

--- a/apm-lambda-extension/e2e-testing/e2e_util.go
+++ b/apm-lambda-extension/e2e-testing/e2e_util.go
@@ -22,7 +22,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -154,7 +153,7 @@ func IsStringInSlice(a string, list []string) bool {
 func GetDecompressedBytesFromRequest(req *http.Request) ([]byte, error) {
 	var rawBytes []byte
 	if req.Body != nil {
-		rawBytes, _ = ioutil.ReadAll(req.Body)
+		rawBytes, _ = io.ReadAll(req.Body)
 	}
 	return apmproxy.GetUncompressedBytes(rawBytes, req.Header.Get("Content-Encoding"))
 }

--- a/apm-lambda-extension/extension/client_test.go
+++ b/apm-lambda-extension/extension/client_test.go
@@ -19,7 +19,7 @@ package extension
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,7 +42,7 @@ func TestRegister(t *testing.T) {
 	`)
 
 	runtimeServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		bytes, _ := ioutil.ReadAll(r.Body)
+		bytes, _ := io.ReadAll(r.Body)
 		assert.Equal(t, expectedRequest, string(bytes))
 		if _, err := w.Write(response); err != nil {
 			t.Fail()

--- a/apm-lambda-extension/extension/logger_test.go
+++ b/apm-lambda-extension/extension/logger_test.go
@@ -18,7 +18,6 @@
 package extension
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -36,7 +35,7 @@ func TestInitLogger(t *testing.T) {
 }
 
 func TestDefaultLogger(t *testing.T) {
-	tempFile, err := ioutil.TempFile(t.TempDir(), "tempFileLoggerTest-")
+	tempFile, err := os.CreateTemp(t.TempDir(), "tempFileLoggerTest-")
 	require.NoError(t, err)
 	defer tempFile.Close()
 
@@ -45,7 +44,7 @@ func TestDefaultLogger(t *testing.T) {
 
 	Log.Infof("%s", "logger-test-info")
 	Log.Debugf("%s", "logger-test-debug")
-	tempFileContents, err := ioutil.ReadFile(tempFile.Name())
+	tempFileContents, err := os.ReadFile(tempFile.Name())
 	require.NoError(t, err)
 	assert.Regexp(t, `{"log.level":"info","@timestamp":".*","log.origin":{"file.name":"extension/logger_test.go","file.line":.*},"message":"logger-test-info","ecs.version":"1.6.0"}`, string(tempFileContents))
 }
@@ -71,7 +70,7 @@ func TestLoggerParseLogLevel(t *testing.T) {
 }
 
 func TestLoggerSetLogLevel(t *testing.T) {
-	tempFile, err := ioutil.TempFile(t.TempDir(), "tempFileLoggerTest-")
+	tempFile, err := os.CreateTemp(t.TempDir(), "tempFileLoggerTest-")
 	require.NoError(t, err)
 	defer tempFile.Close()
 
@@ -83,13 +82,13 @@ func TestLoggerSetLogLevel(t *testing.T) {
 	defer SetLogOutputPaths([]string{"stderr"})
 
 	Log.Debugf("%s", "logger-test-trace")
-	tempFileContents, err := ioutil.ReadFile(tempFile.Name())
+	tempFileContents, err := os.ReadFile(tempFile.Name())
 	require.NoError(t, err)
 	assert.Regexp(t, `{"log.level":"debug","@timestamp":".*","log.origin":{"file.name":"extension/logger_test.go","file.line":.*},"message":"logger-test-trace","ecs.version":"1.6.0"}`, string(tempFileContents))
 }
 
 func TestLoggerSetOffLevel(t *testing.T) {
-	tempFile, err := ioutil.TempFile(t.TempDir(), "tempFileLoggerTest-")
+	tempFile, err := os.CreateTemp(t.TempDir(), "tempFileLoggerTest-")
 	require.NoError(t, err)
 	defer tempFile.Close()
 
@@ -102,7 +101,7 @@ func TestLoggerSetOffLevel(t *testing.T) {
 	defer SetLogOutputPaths([]string{"stderr"})
 
 	Log.Errorf("%s", "logger-test-trace")
-	tempFileContents, err := ioutil.ReadFile(tempFile.Name())
+	tempFileContents, err := os.ReadFile(tempFile.Name())
 	require.NoError(t, err)
 	assert.Equal(t, "", string(tempFileContents))
 }

--- a/apm-lambda-extension/main_test.go
+++ b/apm-lambda-extension/main_test.go
@@ -23,7 +23,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -280,7 +280,7 @@ func processMockEvent(currId string, event MockEvent, extensionPort string, inte
 		}
 		var rawBytes []byte
 		if res.Body != nil {
-			rawBytes, _ = ioutil.ReadAll(res.Body)
+			rawBytes, _ = io.ReadAll(res.Body)
 		}
 		internals.Data += string(rawBytes)
 		extension.Log.Debugf("Response seen by the agent : %d", res.StatusCode)


### PR DESCRIPTION
io/ioutil was deprecated in Go 1.16.

See https://tip.golang.org/doc/go1.16#ioutil

This is needed to support newer version of golangci-lint because
the linters are flagging the usage of io/ioutil as an issue.
Because CI is using the linter for the lint job this is blocking
the update to newer version of go.