### PR TITLE
docs: update release notes for APM Guide

### DIFF
--- a/apm-lambda-extension/CHANGELOG.asciidoc
+++ b/apm-lambda-extension/CHANGELOG.asciidoc
@@ -1,5 +1,6 @@
 ////
-[[release-notes-x.x.x]]
+[float]
+[[lambda-x.x.x]]
 ==== x.x.x - YYYY/MM/DD
 
 [float]
@@ -7,13 +8,14 @@
 
 [float]
 ===== Features
-- Cool new feature: {pull}2526[#2526]
+- Cool new feature: {lambda-pull}2526[#2526]
 
 [float]
 ===== Bug fixes
 ////
 
-[[unreleased]]
+[float]
+[[lambda-unreleased]]
 === Unreleased
 
 https://github.com/elastic/apm-aws-lambda/compare/v1.0.2...main[View commits]
@@ -21,43 +23,43 @@ https://github.com/elastic/apm-aws-lambda/compare/v1.0.2...main[View commits]
 
 [float]
 ==== Features
-- Added support for Secret Manager {pull}208[208]
-- Added support for Lambda platform metrics {pull}202[202]
-- Migrated to AWS SDK for Go v2 {pull}232[232]
+- Added support for Secret Manager {lambda-pull}208[208]
+- Added support for Lambda platform metrics {lambda-pull}202[202]
+- Migrated to AWS SDK for Go v2 {lambda-pull}232[232]
 
 [float]
 ==== Bug fixes
-- Log a warning when authentication with APM Server fails {pull}228[228]
-- Handle http.ErrServerClosed correctly {pull}234[234]
-- Handle main loop errors correctly {pull}252[252]
-- Avoid sending corrupted compressed data to APM Server {pull}257[257]
-- Avoid creating http transports on each info request {pull}260[260]
-- Randomise the initial grace period to avoid collisions {pull}240[240]
+- Log a warning when authentication with APM Server fails {lambda-pull}228[228]
+- Handle http.ErrServerClosed correctly {lambda-pull}234[234]
+- Handle main loop errors correctly {lambda-pull}252[252]
+- Avoid sending corrupted compressed data to APM Server {lambda-pull}257[257]
+- Avoid creating http transports on each info request {lambda-pull}260[260]
+- Randomise the initial grace period to avoid collisions {lambda-pull}240[240]
 
-
-[[release-notes-1.0.2]]
+[float]
+[[lambda-1.0.2]]
 === 1.0.2 - 2022/06/09
 
 https://github.com/elastic/apm-aws-lambda/compare/v1.0.1...v1.0.2[View commits]
 
 [float]
 ==== Bug fixes
-- Only add executables to extension {pull}216[216]
+- Only add executables to extension {lambda-pull}216[216]
 
-
-[[release-notes-1.0.1]]
+[float]
+[[lambda-1.0.1]]
 === 1.0.1 - 2022/06/03
 
 https://github.com/elastic/apm-aws-lambda/compare/v1.0.0...v1.0.1[View commits]
 
 [float]
 ==== Features
-- Add support for building and pushing docker images {pull}199[199]
+- Add support for building and pushing docker images {lambda-pull}199[199]
 
-
-[[release-notes-1.0.0]]
+[float]
+[[lambda-1.0.0]]
 === 1.0.0 - 2022/04/26
 
 https://github.com/elastic/apm-aws-lambda/commits/46e65781912ca0448642e1574c1f8162ffa8dec0[View commits]
 
-First stable release of the Elastic AWS Lambda Extension.
+First stable release of the Elastic APM AWS Lambda extension.


### PR DESCRIPTION
This PR updates the Elastic APM AWS Lambda extension release notes.

- [x] Swap from `[[release-notes-x.x.x]]` ID format to `[[lambda-x.x.x]]`. IDs must be unique and these have the potential to eventually clash with APM Server IDs.
- [x] Swap from `{pull}` to `{lambda-pull}`. The former links to the `apm-server` repo. The latter will link to this repo.
- [x] Add `[float]` tags where required. These release notes will take a slightly different format than the APM release notes. I've adjusted the `[float]` tags and example as necessary.

* For https://github.com/elastic/apm-aws-lambda/issues/268.