### PR TITLE
build: bump go version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   agent { label 'ubuntu-18 && immutable' }
   environment {
     REPO = 'apm-aws-lambda'
+    GO_VERSION = '1.19'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     PIPELINE_LOG_LEVEL = 'INFO'
     SUFFIX_ARN_FILE = 'arn-file.md'
@@ -72,10 +73,6 @@ pipeline {
           axis {
             name 'PLATFORM'
             values 'macosx && x86_64', 'ubuntu-18 && immutable'
-          }
-          axis {
-            name 'GO_VERSION'
-            values '1.18'
           }
         }
         stages {

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -41,8 +41,8 @@ update-licenses:
 	go run github.com/elastic/go-licenser@v0.4.0 -ext .java .
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0 --version
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 version
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 run
 
 build: check-licenses gen-notice
 	GOOS=linux go build -o bin/extensions/apm-lambda-extension main.go

--- a/apm-lambda-extension/go.mod
+++ b/apm-lambda-extension/go.mod
@@ -1,6 +1,6 @@
 module elastic/apm-lambda-extension
 
-go 1.17
+go 1.19
 
 require (
 	github.com/google/uuid v1.3.0


### PR DESCRIPTION
Bump the go version in go.mod to 1.19 and bump
golangci-lint version to support newer versions of go.