### PR TITLE
fix: use the correct timeout for the apmproxy client

### DIFF
--- a/apm-lambda-extension/apmproxy/client.go
+++ b/apm-lambda-extension/apmproxy/client.go
@@ -48,7 +48,6 @@ type Client struct {
 	ServerAPIKey         string
 	ServerSecretToken    string
 	serverURL            string
-	dataForwarderTimeout time.Duration
 	receiver             *http.Server
 	logger               *zap.SugaredLogger
 }
@@ -62,7 +61,6 @@ func NewClient(opts ...Option) (*Client, error) {
 		client: &http.Client{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
 		},
-		dataForwarderTimeout: defaultDataForwarderTimeout,
 		ReconnectionCount:    -1,
 		Status:               Healthy,
 		receiver: &http.Server{
@@ -72,6 +70,8 @@ func NewClient(opts ...Option) (*Client, error) {
 			MaxHeaderBytes: 1 << 20,
 		},
 	}
+
+	c.client.Timeout = defaultDataForwarderTimeout
 
 	for _, opt := range opts {
 		opt(&c)

--- a/apm-lambda-extension/apmproxy/option.go
+++ b/apm-lambda-extension/apmproxy/option.go
@@ -25,12 +25,6 @@ import (
 
 type Option func(*Client)
 
-func WithTimeout(timeout time.Duration) Option {
-	return func(c *Client) {
-		c.client.Timeout = timeout
-	}
-}
-
 func WithAPIKey(key string) Option {
 	return func(c *Client) {
 		c.ServerAPIKey = key
@@ -51,7 +45,7 @@ func WithURL(url string) Option {
 
 func WithDataForwarderTimeout(timeout time.Duration) Option {
 	return func(c *Client) {
-		c.dataForwarderTimeout = timeout
+		c.client.Timeout = timeout
 	}
 }
 

--- a/apm-lambda-extension/apmproxy/receiver.go
+++ b/apm-lambda-extension/apmproxy/receiver.go
@@ -83,7 +83,7 @@ func (c *Client) handleInfoRequest() (func(w http.ResponseWriter, r *http.Reques
 	reverseProxy := httputil.NewSingleHostReverseProxy(parsedApmServerUrl)
 
 	customTransport := http.DefaultTransport.(*http.Transport).Clone()
-	customTransport.ResponseHeaderTimeout = c.dataForwarderTimeout
+	customTransport.ResponseHeaderTimeout = c.client.Timeout
 	reverseProxy.Transport = customTransport
 
 	reverseProxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {


### PR DESCRIPTION
The apmproxy client was using the timeout from the defaulttransport
instead of the user provided one.
Remove unused functional option and make the timeout configuration
more robust.