### PR TITLE
test: reenable main tests

### DIFF
--- a/apm-lambda-extension/app/app.go
+++ b/apm-lambda-extension/app/app.go
@@ -62,9 +62,14 @@ func New(opts ...configOption) (*App, error) {
 	app.extensionClient = extension.NewClient(c.awsLambdaRuntimeAPI, app.logger)
 
 	if !c.disableLogsAPI {
+		addr := "sandbox:0"
+		if c.logsapiAddr != "" {
+			addr = c.logsapiAddr
+		}
+
 		lc, err := logsapi.NewClient(
 			logsapi.WithLogsAPIBaseURL(fmt.Sprintf("http://%s", c.awsLambdaRuntimeAPI)),
-			logsapi.WithListenerAddress("sandbox:0"),
+			logsapi.WithListenerAddress(addr),
 			logsapi.WithLogBuffer(100),
 			logsapi.WithLogger(app.logger),
 		)

--- a/apm-lambda-extension/app/config.go
+++ b/apm-lambda-extension/app/config.go
@@ -22,6 +22,7 @@ type appConfig struct {
 	extensionName       string
 	disableLogsAPI      bool
 	logLevel            string
+	logsapiAddr         string
 }
 
 type configOption func(*appConfig)
@@ -53,5 +54,13 @@ func WithoutLogsAPI() configOption {
 func WithLogLevel(level string) configOption {
 	return func(c *appConfig) {
 		c.logLevel = level
+	}
+}
+
+// WithLogsapiAddress sets the listener address of the
+// server listening for logs event.
+func WithLogsapiAddress(s string) configOption {
+	return func(c *appConfig) {
+		c.logsapiAddr = s
 	}
 }


### PR DESCRIPTION
main_test was disabled after the global state for the logsapi
listener was removed.
The new approach is to choose a random port and pass the address
to the app.
Add a timeout to make sure tests don't hang.

Blocked by https://github.com/elastic/apm-aws-lambda/issues/249

Closes https://github.com/elastic/apm-aws-lambda/issues/249