### PR TITLE
ci: use make in PRs

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -53,10 +53,10 @@ pipeline {
           }
         }
         withGithubNotify(context: "NOTICE.txt") {
-          dir("${BASE_DIR}"){
-            withGoEnv(){
+          withGoEnv(){
+            dir("${BASE_DIR}/apm-lambda-extension"){
               sh(label: 'notice', script: '''
-                bash ./apm-lambda-extension/scripts/notice.sh
+                make NOTICE.txt
                 git diff --exit-code --quiet && exit 0 || echo "regenerate NOTICE.txt" && exit 1
               ''')
             }
@@ -83,7 +83,7 @@ pipeline {
                 unstash 'source'
                 withGoEnv(){
                   dir("${BASE_DIR}/apm-lambda-extension"){
-                    cmd(label: 'Go build', script: 'go build')
+                    cmd(label: 'make build', script: 'make build')
                   }
                 }
               }

--- a/apm-lambda-extension/Makefile
+++ b/apm-lambda-extension/Makefile
@@ -25,8 +25,7 @@ export AWS_FOLDER GOARCH ARCHITECTURE DOCKER_IMAGE_NAME DOCKER_REGISTRY
 .PHONY: all
 all: build
 
-.PHONY: gen-notice
-gen-notice:
+NOTICE.txt: go.mod
 	@bash ./scripts/notice.sh
 
 check-licenses:
@@ -44,7 +43,7 @@ lint:
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 version
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 run
 
-build: check-licenses gen-notice
+build: check-licenses NOTICE.txt
 	GOOS=linux go build -o bin/extensions/apm-lambda-extension main.go
 	cp NOTICE.txt bin/NOTICE.txt
 	cp dependencies.asciidoc bin/dependencies.asciidoc
@@ -59,17 +58,21 @@ endif
 	GOARCH=${GOARCH} make build
 	GOARCH=${GOARCH} make zip
 	$(MAKE) publish
-zip:
+
+zip: build
 	cd bin \
 	&& rm -f extension.zip \
 	&& find extensions NOTICE.txt dependencies.asciidoc | xargs touch -d @$(SOURCE_DATE_EPOCH) \
 	&& zip -X -r extension.zip extensions NOTICE.txt dependencies.asciidoc \
 	&& cp extension.zip ${GOARCH}.zip
+
 test:
 	go test extension/*.go -v
+
 env:
 	env
-dist: validate-branch-name build test zip
+
+dist: validate-branch-name test zip
 	@cp ./bin/$(GOARCH).zip bin/$(BRANCH_NAME)-linux-$(GOARCH).zip
 
 build-docker: validate-version


### PR DESCRIPTION
Use Make targets, so CI behaves more like developer environments. This ensures license headers are checked in PRs.

Also, tidy up the Makefile a little:
- `zip` now depends on `build`. This ensures a `make zip` in isolation won't zip a stale build and confuse unsuspecting people like me.
- replace `gen-notice` with a non-PHONY `NOTICE.txt` target, by depending on go.mod