### PR TITLE
feat: disable cgo

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ https://github.com/elastic/apm-aws-lambda/compare/v1.1.0...main[View commits]
 
 [float]
 ===== Features
+- Disable CGO to prevent libc/ABI compatibility issues {lambda-pull}292[292]
 
 [float]
 ===== Bug fixes

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint:
 	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0 run
 
 build: check-licenses NOTICE.txt
-	GOOS=linux go build -o bin/extensions/apm-lambda-extension main.go
+	CGO_ENABLED=0 GOOS=linux go build -o bin/extensions/apm-lambda-extension main.go
 	cp NOTICE.txt bin/NOTICE.txt
 	cp dependencies.asciidoc bin/dependencies.asciidoc
 


### PR DESCRIPTION
build the extension with cgo disabled, to ensure there are
no glibc/ABI compatibility issues between the build host and
the target Lambda execution environment.

Closes https://github.com/elastic/apm-aws-lambda/issues/290