### PR TITLE
feat: replace timeout seconds option with timeout durations

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -83,20 +83,18 @@ func New(opts ...configOption) (*App, error) {
 
 	var apmOpts []apmproxy.Option
 
-	receiverTimeoutSeconds, err := getIntFromEnvIfAvailable("ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS")
-	if err != nil {
-		return nil, err
-	}
-	if receiverTimeoutSeconds != 0 {
-		apmOpts = append(apmOpts, apmproxy.WithReceiverTimeout(time.Duration(receiverTimeoutSeconds)*time.Second))
+	if receiverTimeout, ok, err := parseDurationTimeout(app.logger, "ELASTIC_APM_DATA_RECEIVER_TIMEOUT", "ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS"); err != nil || ok {
+		if err != nil {
+			return nil, err
+		}
+		apmOpts = append(apmOpts, apmproxy.WithReceiverTimeout(receiverTimeout))
 	}
 
-	dataForwarderTimeoutSeconds, err := getIntFromEnvIfAvailable("ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS")
-	if err != nil {
-		return nil, err
-	}
-	if dataForwarderTimeoutSeconds != 0 {
-		apmOpts = append(apmOpts, apmproxy.WithDataForwarderTimeout(time.Duration(dataForwarderTimeoutSeconds)*time.Second))
+	if dataForwarderTimeout, ok, err := parseDurationTimeout(app.logger, "ELASTIC_APM_DATA_FORWARDER_TIMEOUT", "ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS"); err != nil || ok {
+		if err != nil {
+			return nil, err
+		}
+		apmOpts = append(apmOpts, apmproxy.WithDataForwarderTimeout(dataForwarderTimeout))
 	}
 
 	if port := os.Getenv("ELASTIC_APM_DATA_RECEIVER_SERVER_PORT"); port != "" {
@@ -129,17 +127,28 @@ func New(opts ...configOption) (*App, error) {
 	return app, nil
 }
 
-func getIntFromEnvIfAvailable(name string) (int, error) {
-	strValue := os.Getenv(name)
-	if strValue == "" {
-		return 0, nil
+func parseDurationTimeout(l *zap.SugaredLogger, flag string, deprecatedFlag string) (time.Duration, bool, error) {
+	if strValue, ok := os.LookupEnv(flag); ok {
+		d, err := time.ParseDuration(strValue)
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to parse %s: %w", flag, err)
+		}
+
+		return d, true, nil
 	}
 
-	value, err := strconv.Atoi(strValue)
-	if err != nil {
-		return -1, err
+	l.Warnf("%s is deprecated, please consider moving to %s", deprecatedFlag, flag)
+
+	if strValueSeconds, ok := os.LookupEnv(deprecatedFlag); ok {
+		seconds, err := strconv.Atoi(strValueSeconds)
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to parse %s: %w", deprecatedFlag, err)
+		}
+
+		return time.Duration(seconds) * time.Second, true, nil
 	}
-	return value, nil
+
+	return 0, false, nil
 }
 
 func parseStrategy(value string) (apmproxy.SendStrategy, bool) {

--- a/docs/monitoring-aws-lambda.asciidoc
+++ b/docs/monitoring-aws-lambda.asciidoc
@@ -88,12 +88,18 @@ The configured name of your application or service.  The APM agent will use this
 === `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS`
 The {apm-lambda-ext}'s timeout value, in seconds, for receiving data from the APM agent. The _default_ is `15`.
 
+=== `ELASTIC_APM_DATA_RECEIVER_TIMEOUT`
+The {apm-lambda-ext}'s timeout value, for receiving data from the APM agent. The _default_ is `15s`.
+
 === `ELASTIC_APM_DATA_RECEIVER_SERVER_PORT`
 The port on which the {apm-lambda-ext} listens to receive data from the APM agent. The _default_ is `8200`.
 
-[[aws-lambda-config-data-forwarder-timeout]]
 === `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS`
 The timeout value, in seconds, for the {apm-lambda-ext}'s HTTP client sending data to the APM Server. The _default_ is `3`. If the extension's attempt to send APM data during this time interval is not successful, the extension queues back the data. Further attempts at sending the data are governed by an exponential backoff algorithm: data will be sent after a increasingly large grace period of 0, then circa 1, 4, 9, 16, 25 and 36 seconds, provided that the Lambda function execution is ongoing.
+
+[[aws-lambda-config-data-forwarder-timeout]]
+=== `ELASTIC_APM_DATA_FORWARDER_TIMEOUT`
+The timeout value, for the {apm-lambda-ext}'s HTTP client sending data to the APM Server. The _default_ is `3s`. If the extension's attempt to send APM data during this time interval is not successful, the extension queues back the data. Further attempts at sending the data are governed by an exponential backoff algorithm: data will be sent after a increasingly large grace period of 0, then circa 1, 4, 9, 16, 25 and 36 seconds, provided that the Lambda function execution is ongoing.
 
 === `ELASTIC_APM_SEND_STRATEGY`
 Whether to synchronously flush APM agent data from the {apm-lambda-ext} to the APM Server at the end of the function invocation.

--- a/main_test.go
+++ b/main_test.go
@@ -531,7 +531,7 @@ func TestAPMServerRecovery(t *testing.T) {
 	logsapiAddr := randomAddr()
 	newMockLambdaServer(t, logsapiAddr, eventsChannel, l)
 
-	t.Setenv("ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS", "1")
+	t.Setenv("ELASTIC_APM_DATA_FORWARDER_TIMEOUT", "1s")
 
 	eventsChain := []MockEvent{
 		{Type: InvokeStandard, APMServerBehavior: Hangs, ExecutionDuration: 1, Timeout: 5},


### PR DESCRIPTION
Deprecate TIMEOUT_SECONDS options in favour of simpler TIMEOUT options.
The new options take a duration as a more user-friendly and flexible
input. It will always take precedence over the old option.
If the old option is provided, a warning is printed out.