### PR TITLE
Copy metadata to avoid corruption

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ https://github.com/elastic/apm-aws-lambda/compare/v1.1.0...main[View commits]
 
 [float]
 ===== Bug fixes
+- Fix possible data corruption while processing multiple log events {lambda-pull}309[309]
 
 [float]
 [[lambda-1.1.0]]

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -19,9 +19,10 @@ package logsapi
 
 import (
 	"context"
-	"github.com/elastic/apm-aws-lambda/extension"
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"time"
+
+	"github.com/elastic/apm-aws-lambda/apmproxy"
+	"github.com/elastic/apm-aws-lambda/extension"
 )
 
 // EventType represents the type of logs in Lambda

--- a/logsapi/metrics.go
+++ b/logsapi/metrics.go
@@ -18,6 +18,7 @@
 package logsapi
 
 import (
+	"errors"
 	"math"
 
 	"github.com/elastic/apm-aws-lambda/apmproxy"
@@ -63,6 +64,11 @@ func (mc MetricsContainer) MarshalFastJSON(json *fastjson.Writer) error {
 }
 
 func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.AgentData, error) {
+
+	if metadataContainer == nil || len(metadataContainer.Metadata) == 0 {
+		return apmproxy.AgentData{}, errors.New("metadata is not populated")
+	}
+
 	metricsContainer := MetricsContainer{
 		Metrics: &model.Metrics{},
 	}

--- a/logsapi/metrics.go
+++ b/logsapi/metrics.go
@@ -63,7 +63,6 @@ func (mc MetricsContainer) MarshalFastJSON(json *fastjson.Writer) error {
 }
 
 func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.AgentData, error) {
-	var metricsData []byte
 	metricsContainer := MetricsContainer{
 		Metrics: &model.Metrics{},
 	}
@@ -101,10 +100,11 @@ func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functi
 		return apmproxy.AgentData{}, err
 	}
 
-	if metadataContainer.Metadata != nil {
-		metricsData = append(metadataContainer.Metadata, []byte("\n")...)
-	}
+	capacity := len(metadataContainer.Metadata) + jsonWriter.Size() + 1 // 1 for newline
+	metricsData := make([]byte, len(metadataContainer.Metadata), capacity)
+	copy(metricsData, metadataContainer.Metadata)
 
+	metricsData = append(metricsData, []byte("\n")...)
 	metricsData = append(metricsData, jsonWriter.Bytes()...)
 	return apmproxy.AgentData{Data: metricsData}, nil
 }

--- a/logsapi/metrics_test.go
+++ b/logsapi/metrics_test.go
@@ -184,7 +184,7 @@ func TestProcessPlatformReport_DataCorruption(t *testing.T) {
 	agentData, err := ProcessPlatformReport(mc, nextEventResp, logEvent)
 	require.NoError(t, err)
 
-	// process another metadata to corroupt the already processed one
+	// process another platform report to ensure the previous payload is not corrupted
 	logEvent.Record.RequestID = "corrupt-req-id"
 	nextEventResp.RequestID = "corrupt-req-id"
 	_, err = ProcessPlatformReport(mc, nextEventResp, logEvent)

--- a/logsapi/metrics_test.go
+++ b/logsapi/metrics_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_processPlatformReportColdstart(t *testing.T) {
+func TestProcessPlatformReport_Coldstart(t *testing.T) {
 	mc := apmproxy.MetadataContainer{
 		Metadata: []byte(fmt.Sprintf(`{"metadata":{"service":{"agent":{"name":"apm-lambda-extension","version":"%s"},"framework":{"name":"AWS Lambda","version":""},"language":{"name":"python","version":"3.9.8"},"runtime":{"name":"","version":""},"node":{}},"user":{},"process":{"pid":0},"system":{"container":{"id":""},"kubernetes":{"node":{},"pod":{}}},"cloud":{"provider":"","instance":{},"machine":{},"account":{},"project":{},"service":{}}}}`, extension.Version)),
 	}
@@ -90,7 +90,7 @@ func Test_processPlatformReportColdstart(t *testing.T) {
 	assert.JSONEq(t, desiredOutputMetrics, processingResult[1])
 }
 
-func Test_processPlatformReportNoColdstart(t *testing.T) {
+func TestProcessPlatformReport_NoColdstart(t *testing.T) {
 
 	mc := apmproxy.MetadataContainer{
 		Metadata: []byte(fmt.Sprintf(`{"metadata":{"service":{"agent":{"name":"apm-lambda-extension","version":"%s"},"framework":{"name":"AWS Lambda","version":""},"language":{"name":"python","version":"3.9.8"},"runtime":{"name":"","version":""},"node":{}},"user":{},"process":{"pid":0},"system":{"container":{"id":""},"kubernetes":{"node":{},"pod":{}}},"cloud":{"provider":"","instance":{},"machine":{},"account":{},"project":{},"service":{}}}}`, extension.Version)),
@@ -148,4 +148,82 @@ func Test_processPlatformReportNoColdstart(t *testing.T) {
 
 	assert.JSONEq(t, desiredOutputMetadata, processingResult[0])
 	assert.JSONEq(t, desiredOutputMetrics, processingResult[1])
+}
+
+func TestProcessPlatformReport_DataCorruption(t *testing.T) {
+	// Allocate big capacity metadata array to prevent reallocation
+	raw := make([]byte, 0, 7000)
+	mc := &apmproxy.MetadataContainer{
+		Metadata: append(raw, []byte(fmt.Sprintf(`{"metadata":{"service":{"agent":{"name":"apm-lambda-extension","version":"%s"},"framework":{"name":"AWS Lambda","version":""},"language":{"name":"python","version":"3.9.8"},"runtime":{"name":"","version":""},"node":{}},"user":{},"process":{"pid":0},"system":{"container":{"id":""},"kubernetes":{"node":{},"pod":{}}},"cloud":{"provider":"","instance":{},"machine":{},"account":{},"project":{},"service":{}}}}`, extension.Version))...),
+	}
+	reqID := "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
+	invokedFnArn := "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime"
+	timestamp := time.Date(2022, 11, 12, 0, 0, 0, 0, time.UTC)
+	logEvent := LogEvent{
+		Time: timestamp,
+		Type: Report,
+		Record: LogEventRecord{
+			RequestID: reqID,
+			Metrics: PlatformMetrics{
+				DurationMs:       1.0,
+				BilledDurationMs: 1,
+				MemorySizeMB:     1,
+				MaxMemoryUsedMB:  1,
+				InitDurationMs:   1.0,
+			},
+		},
+	}
+	nextEventResp := &extension.NextEventResponse{
+		Timestamp:          timestamp,
+		EventType:          extension.Invoke,
+		RequestID:          reqID,
+		InvokedFunctionArn: invokedFnArn,
+	}
+	expected := "{\"metricset\":{\"samples\":{\"system.memory.total\":{\"value\":1.048576e+06},\"system.memory.actual.free\":{\"value\":0},\"faas.duration\":{\"value\":1},\"faas.billed_duration\":{\"value\":1},\"faas.coldstart_duration\":{\"value\":1},\"faas.timeout\":{\"value\":-1.6682112e+12}},\"timestamp\":1668211200000000,\"faas\":{\"coldstart\":true,\"execution\":\"8476a536-e9f4-11e8-9739-2dfe598c3fcd\",\"id\":\"arn:aws:lambda:us-east-2:123456789012:function:custom-runtime\"}}}"
+
+	agentData, err := ProcessPlatformReport(mc, nextEventResp, logEvent)
+	require.NoError(t, err)
+
+	// process another metadata to corroupt the already processed one
+	logEvent.Record.RequestID = "corrupt-req-id"
+	nextEventResp.RequestID = "corrupt-req-id"
+	_, err = ProcessPlatformReport(mc, nextEventResp, logEvent)
+	require.NoError(t, err)
+
+	data := strings.Split(string(agentData.Data), "\n")
+	assert.JSONEq(t, expected, data[1])
+}
+
+func BenchmarkPlatformReport(b *testing.B) {
+	mc := &apmproxy.MetadataContainer{
+		Metadata: []byte(`{"metadata":{"service":{"agent":{"name":"apm-lambda-extension","version":"1.1.0"},"framework":{"name":"AWS Lambda","version":""},"language":{"name":"python","version":"3.9.8"},"runtime":{"name":"","version":""},"node":{}},"user":{},"process":{"pid":0},"system":{"container":{"id":""},"kubernetes":{"node":{},"pod":{}}},"cloud":{"provider":"","instance":{},"machine":{},"account":{},"project":{},"service":{}}}}`),
+	}
+	reqID := "8476a536-e9f4-11e8-9739-2dfe598c3fcd"
+	invokedFnArn := "arn:aws:lambda:us-east-2:123456789012:function:custom-runtime"
+	timestamp := time.Date(2022, 11, 12, 0, 0, 0, 0, time.UTC)
+	logEvent := LogEvent{
+		Time: timestamp,
+		Type: Report,
+		Record: LogEventRecord{
+			RequestID: reqID,
+			Metrics: PlatformMetrics{
+				DurationMs:       1.0,
+				BilledDurationMs: 1,
+				MemorySizeMB:     1,
+				MaxMemoryUsedMB:  1,
+				InitDurationMs:   1.0,
+			},
+		},
+	}
+	nextEventResp := &extension.NextEventResponse{
+		Timestamp:          timestamp,
+		EventType:          extension.Invoke,
+		RequestID:          reqID,
+		InvokedFunctionArn: invokedFnArn,
+	}
+
+	for n := 0; n < b.N; n++ {
+		_, err := ProcessPlatformReport(mc, nextEventResp, logEvent)
+		require.NoError(b, err)
+	}
 }

--- a/testdata/function/index.js
+++ b/testdata/function/index.js
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 exports.handler = async (event) => {
     const response = {
         statusCode: 200,


### PR DESCRIPTION
Makes a copy of the metadata to process log event in order to avoid corruption.

Fixes: #308 