### PR TITLE
Batch events and buffer events from logs API until metadata is available

### DIFF
--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -93,7 +93,7 @@ func (c *Client) FlushAPMData(ctx context.Context) {
 // The function compresses the APM agent data, if it's not already compressed.
 // It sets the APM transport status to failing upon errors, as part of the backoff
 // strategy.
-func (c *Client) PostToApmServer(ctx context.Context, agentData AgentData) error {
+func (c *Client) PostToApmServer(ctx context.Context, agentData APMData) error {
 	// todo: can this be a streaming or streaming style call that keeps the
 	//       connection open across invocations?
 	if c.IsUnhealthy() {
@@ -283,7 +283,7 @@ func (c *Client) ComputeGracePeriod() time.Duration {
 
 // EnqueueAPMData adds a AgentData struct to the agent data channel, effectively queueing for a send
 // to the APM server.
-func (c *Client) EnqueueAPMData(agentData AgentData) {
+func (c *Client) EnqueueAPMData(agentData APMData) {
 	select {
 	case c.DataChannel <- agentData:
 		c.logger.Debug("Adding agent data to buffer to be sent to apm server")

--- a/apmproxy/apmserver_test.go
+++ b/apmproxy/apmserver_test.go
@@ -78,6 +78,7 @@ func TestPostToApmServerDataCompressed(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	require.NoError(t, apmClient.PostToApmServer(context.Background(), agentData))
@@ -124,6 +125,7 @@ func TestPostToApmServerDataNotCompressed(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	require.NoError(t, apmClient.PostToApmServer(context.Background(), agentData))
@@ -133,6 +135,7 @@ func TestGracePeriod(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -173,6 +176,7 @@ func TestSetHealthyTransport(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -186,6 +190,7 @@ func TestSetFailingTransport(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.ReconnectionCount = 0
@@ -198,6 +203,7 @@ func TestSetPendingTransport(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -213,6 +219,7 @@ func TestSetPendingTransportExplicitly(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -225,6 +232,7 @@ func TestSetInvalidTransport(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL("https://example.com"),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -269,6 +277,7 @@ func TestEnterBackoffFromHealthy(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -323,6 +332,7 @@ func TestEnterBackoffFromFailing(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -377,6 +387,7 @@ func TestAPMServerRecovery(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -423,6 +434,7 @@ func TestAPMServerAuthFails(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -474,6 +486,7 @@ func TestAPMServerRatelimit(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, apmClient.Status, apmproxy.Started)
@@ -527,6 +540,7 @@ func TestAPMServerClientFail(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	assert.Equal(t, apmClient.Status, apmproxy.Started)
@@ -577,6 +591,7 @@ func TestContinuedAPMServerFailure(t *testing.T) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	apmClient.UpdateStatus(context.Background(), apmproxy.Healthy)
@@ -639,6 +654,14 @@ func TestForwardApmData(t *testing.T) {
 		Type: apmproxy.Agent,
 	}
 	assertGzipBody(agentData)
+	// After reading agent data with metadata the metadata indicator
+	// channel should be closed
+	select {
+	case _, ok := <-metaAvailable:
+		require.False(t, ok)
+	default:
+		require.Fail(t, "meta channel should be closed after reading agent data")
+	}
 
 	// Send lambda logs API data
 	var expected bytes.Buffer
@@ -679,6 +702,7 @@ func BenchmarkFlushAPMData(b *testing.B) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(b).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(b, err)
 
@@ -725,6 +749,7 @@ func BenchmarkPostToAPM(b *testing.B) {
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
 		apmproxy.WithLogger(zaptest.NewLogger(b).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(b, err)
 

--- a/apmproxy/apmserver_test.go
+++ b/apmproxy/apmserver_test.go
@@ -18,11 +18,14 @@
 package apmproxy_test
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -586,6 +589,115 @@ func TestContinuedAPMServerFailure(t *testing.T) {
 	assert.Equal(t, apmClient.Status, apmproxy.Failing)
 }
 
+func TestForwardApmData(t *testing.T) {
+	receivedReqBodyChan := make(chan []byte)
+	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bytes, _ := io.ReadAll(r.Body)
+		receivedReqBodyChan <- bytes
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(apmServer.Close)
+	metadata := `{"metadata":{"service":{"agent":{"name":"apm-lambda-extension","version":"1.1.0"},"framework":{"name":"AWS Lambda","version":""},"language":{"name":"python","version":"3.9.8"},"runtime":{"name":"","version":""},"node":{}},"user":{},"process":{"pid":0},"system":{"container":{"id":""},"kubernetes":{"node":{},"pod":{}}},"cloud":{"provider":"","instance":{},"machine":{},"account":{},"project":{},"service":{}}}}`
+	assertGzipBody := func(expected string) {
+		buf := bytes.NewReader(<-receivedReqBodyChan)
+		r, err := gzip.NewReader(buf)
+		require.NoError(t, err)
+		out, err := io.ReadAll(r)
+		require.NoError(t, err)
+		assert.Equal(t, expected, string(out))
+	}
+	agentData := fmt.Sprintf("%s\n%s", metadata, `{"log": {"message": "test"}}`)
+	lambdaData := `{"log": {"message": "test"}}`
+	apmClient, err := apmproxy.NewClient(
+		apmproxy.WithURL(apmServer.URL),
+		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+	)
+	require.NoError(t, err)
+	// Override DataChannel to be unbuffered for ease of testing
+	apmClient.DataChannel = make(chan apmproxy.APMData)
+
+	// Start forwarding APM data
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		assert.NoError(t, apmClient.ForwardApmData(ctx))
+	}()
+
+	// Populate metadata by sending agent data
+	apmClient.DataChannel <- apmproxy.APMData{
+		Data: []byte(agentData),
+		Type: apmproxy.Agent,
+	}
+	assertGzipBody(agentData)
+
+	// Send lambda logs API data
+	var expected bytes.Buffer
+	expected.WriteString(metadata)
+	// Send multiple lambda logs to batch data
+	for i := 0; i < 5; i++ {
+		apmClient.DataChannel <- apmproxy.APMData{
+			Data: []byte(lambdaData),
+			Type: apmproxy.Lambda,
+		}
+		expected.WriteByte('\n')
+		expected.WriteString(lambdaData)
+	}
+
+	// Trigger a batch send by cancelling context
+	cancel()
+	assertGzipBody(expected.String())
+	// Wait for ForwardApmData to exit
+	wg.Wait()
+}
+
+func BenchmarkFlushAPMData(b *testing.B) {
+	// Create apm server and handler
+	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := io.Copy(io.Discard, r.Body); err != nil {
+			return
+		}
+		if err := r.Body.Close(); err != nil {
+			return
+		}
+		w.WriteHeader(202)
+		if _, err := w.Write([]byte(`{}`)); err != nil {
+			return
+		}
+	}))
+	b.Cleanup(apmServer.Close)
+
+	apmClient, err := apmproxy.NewClient(
+		apmproxy.WithURL(apmServer.URL),
+		apmproxy.WithLogger(zaptest.NewLogger(b).Sugar()),
+	)
+	require.NoError(b, err)
+
+	// Copied from https://github.com/elastic/apm-server/blob/master/testdata/intake-v2/transactions.ndjson.
+	agentData := []byte(`{"metadata": {"service": {"name": "1234_service-12a3","node": {"configured_name": "node-123"},"version": "5.1.3","environment": "staging","language": {"name": "ecmascript","version": "8"},"runtime": {"name": "node","version": "8.0.0"},"framework": {"name": "Express","version": "1.2.3"},"agent": {"name": "elastic-node","version": "3.14.0"}},"user": {"id": "123user", "username": "bar", "email": "bar@user.com"}, "labels": {"tag0": null, "tag1": "one", "tag2": 2}, "process": {"pid": 1234,"ppid": 6789,"title": "node","argv": ["node","server.js"]},"system": {"hostname": "prod1.example.com","architecture": "x64","platform": "darwin", "container": {"id": "container-id"}, "kubernetes": {"namespace": "namespace1", "pod": {"uid": "pod-uid", "name": "pod-name"}, "node": {"name": "node-name"}}},"cloud":{"account":{"id":"account_id","name":"account_name"},"availability_zone":"cloud_availability_zone","instance":{"id":"instance_id","name":"instance_name"},"machine":{"type":"machine_type"},"project":{"id":"project_id","name":"project_name"},"provider":"cloud_provider","region":"cloud_region","service":{"name":"lambda"}}}}
+{"transaction": { "id": "945254c567a5417e", "trace_id": "0123456789abcdef0123456789abcdef", "parent_id": "abcdefabcdef01234567", "type": "request", "duration": 32.592981,  "span_count": { "started": 43 }}}
+{"transaction": {"id": "4340a8e0df1906ecbfa9", "trace_id": "0acd456789abcdef0123456789abcdef", "name": "GET /api/types","type": "request","duration": 32.592981,"outcome":"success", "result": "success", "timestamp": 1496170407154000, "sampled": true, "span_count": {"started": 17},"context": {"service": {"runtime": {"version": "7.0"}},"page":{"referer":"http://localhost:8000/test/e2e/","url":"http://localhost:8000/test/e2e/general-usecase/"}, "request": {"socket": {"remote_address": "12.53.12.1","encrypted": true},"http_version": "1.1","method": "POST","url": {"protocol": "https:","full": "https://www.example.com/p/a/t/h?query=string#hash","hostname": "www.example.com","port": "8080","pathname": "/p/a/t/h","search": "?query=string","hash": "#hash","raw": "/p/a/t/h?query=string#hash"},"headers": {"user-agent":["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","Mozilla Chrome Edge"],"content-type": "text/html","cookie": "c1=v1, c2=v2","some-other-header": "foo","array": ["foo","bar","baz"]},"cookies": {"c1": "v1","c2": "v2"},"env": {"SERVER_SOFTWARE": "nginx","GATEWAY_INTERFACE": "CGI/1.1"},"body": {"str": "hello world","additional": { "foo": {},"bar": 123,"req": "additional information"}}},"response": {"status_code": 200,"headers": {"content-type": "application/json"},"headers_sent": true,"finished": true,"transfer_size":25.8,"encoded_body_size":26.90,"decoded_body_size":29.90}, "user": {"domain": "ldap://abc","id": "99","username": "foo"},"tags": {"organization_uuid": "9f0e9d64-c185-4d21-a6f4-4673ed561ec8", "tag2": 12, "tag3": 12.45, "tag4": false, "tag5": null },"custom": {"my_key": 1,"some_other_value": "foo bar","and_objects": {"foo": ["bar","baz"]},"(": "not a valid regex and that is fine"}}}}
+{"transaction": { "id": "cdef4340a8e0df19", "trace_id": "0acd456789abcdef0123456789abcdef", "type": "request", "duration": 13.980558, "timestamp": 1532976822281000, "sampled": null, "span_count": { "dropped": 55, "started": 436 }, "marks": {"navigationTiming": {"appBeforeBootstrap": 608.9300000000001,"navigationStart": -21},"another_mark": {"some_long": 10,"some_float": 10.0}, "performance": {}}, "context": { "request": { "socket": { "remote_address": "192.0.1", "encrypted": null }, "method": "POST", "headers": { "user-agent": null, "content-type": null, "cookie": null }, "url": { "protocol": null, "full": null, "hostname": null, "port": null, "pathname": null, "search": null, "hash": null, "raw": null } }, "response": { "headers": { "content-type": null } }, "service": {"environment":"testing","name": "service1","node": {"configured_name": "node-ABC"}, "language": {"version": "2.5", "name": "ruby"}, "agent": {"version": "2.2", "name": "elastic-ruby", "ephemeral_id": "justanid"}, "framework": {"version": "5.0", "name": "Rails"}, "version": "2", "runtime": {"version": "2.5", "name": "cruby"}}},"experience":{"cls":1,"fid":2.0,"tbt":3.4,"longtask":{"count":3,"sum":2.5,"max":1}}}}
+{"transaction": { "id": "00xxxxFFaaaa1234", "trace_id": "0123456789abcdef0123456789abcdef", "name": "amqp receive", "parent_id": "abcdefabcdef01234567", "type": "messaging", "duration": 3, "span_count": { "started": 1 }, "context": {"message": {"queue": { "name": "new_users"}, "age":{ "ms": 1577958057123}, "headers": {"user_id": "1ax3", "involved_services": ["user", "auth"]}, "body": "user created", "routing_key": "user-created-transaction"}},"session":{"id":"sunday","sequence":123}}}
+{"transaction": { "name": "july-2021-delete-after-july-31", "type": "lambda", "result": "success", "id": "142e61450efb8574", "trace_id": "eb56529a1f461c5e7e2f66ecb075e983", "subtype": null, "action": null, "duration": 38.853, "timestamp": 1631736666365048, "sampled": true, "context": { "cloud": { "origin": { "account": { "id": "abc123" }, "provider": "aws", "region": "us-east-1", "service": { "name": "serviceName" } } }, "service": { "origin": { "id": "abc123", "name": "service-name", "version": "1.0" } }, "user": {}, "tags": {}, "custom": { } }, "sync": true, "span_count": { "started": 0 }, "outcome": "unknown", "faas": { "coldstart": false, "execution": "2e13b309-23e1-417f-8bf7-074fc96bc683", "trigger": { "request_id": "FuH2Cir_vHcEMUA=", "type": "http" } }, "sample_rate": 1 } }
+`)
+	agentAPMData := apmproxy.APMData{Data: agentData, Type: apmproxy.Agent}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		apmClient.DataChannel <- agentAPMData
+		for j := 0; j < 99; j++ {
+			apmClient.DataChannel <- apmproxy.APMData{
+				Data: []byte("this is test log"),
+				Type: apmproxy.Lambda,
+			}
+		}
+		apmClient.FlushAPMData(context.Background())
+	}
+}
+
 func BenchmarkPostToAPM(b *testing.B) {
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -600,6 +712,7 @@ func BenchmarkPostToAPM(b *testing.B) {
 			return
 		}
 	}))
+	b.Cleanup(apmServer.Close)
 
 	apmClient, err := apmproxy.NewClient(
 		apmproxy.WithURL(apmServer.URL),
@@ -617,6 +730,7 @@ func BenchmarkPostToAPM(b *testing.B) {
 `)
 	agentData := apmproxy.APMData{Data: benchBody, ContentEncoding: ""}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		if err := apmClient.PostToApmServer(context.Background(), agentData); err != nil {

--- a/apmproxy/apmserver_test.go
+++ b/apmproxy/apmserver_test.go
@@ -57,7 +57,7 @@ func TestPostToApmServerDataCompressed(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -83,7 +83,7 @@ func TestPostToApmServerDataCompressed(t *testing.T) {
 func TestPostToApmServerDataNotCompressed(t *testing.T) {
 	s := "A long time ago in a galaxy far, far away..."
 	body := []byte(s)
-	agentData := apmproxy.AgentData{Data: body, ContentEncoding: ""}
+	agentData := apmproxy.APMData{Data: body, ContentEncoding: ""}
 
 	// Compress the data, so it can be compared with what
 	// the apm server receives
@@ -251,7 +251,7 @@ func TestEnterBackoffFromHealthy(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -302,7 +302,7 @@ func TestEnterBackoffFromFailing(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -356,7 +356,7 @@ func TestAPMServerRecovery(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -409,7 +409,7 @@ func TestAPMServerAuthFails(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -453,7 +453,7 @@ func TestAPMServerRatelimit(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	var shouldSucceed atomic.Bool
@@ -506,7 +506,7 @@ func TestAPMServerClientFail(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	var shouldSucceed atomic.Bool
@@ -558,7 +558,7 @@ func TestContinuedAPMServerFailure(t *testing.T) {
 
 	// Create AgentData struct with compressed data
 	data, _ := io.ReadAll(pr)
-	agentData := apmproxy.AgentData{Data: data, ContentEncoding: "gzip"}
+	agentData := apmproxy.APMData{Data: data, ContentEncoding: "gzip"}
 
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -615,7 +615,7 @@ func BenchmarkPostToAPM(b *testing.B) {
 {"transaction": { "id": "00xxxxFFaaaa1234", "trace_id": "0123456789abcdef0123456789abcdef", "name": "amqp receive", "parent_id": "abcdefabcdef01234567", "type": "messaging", "duration": 3, "span_count": { "started": 1 }, "context": {"message": {"queue": { "name": "new_users"}, "age":{ "ms": 1577958057123}, "headers": {"user_id": "1ax3", "involved_services": ["user", "auth"]}, "body": "user created", "routing_key": "user-created-transaction"}},"session":{"id":"sunday","sequence":123}}}
 {"transaction": { "name": "july-2021-delete-after-july-31", "type": "lambda", "result": "success", "id": "142e61450efb8574", "trace_id": "eb56529a1f461c5e7e2f66ecb075e983", "subtype": null, "action": null, "duration": 38.853, "timestamp": 1631736666365048, "sampled": true, "context": { "cloud": { "origin": { "account": { "id": "abc123" }, "provider": "aws", "region": "us-east-1", "service": { "name": "serviceName" } } }, "service": { "origin": { "id": "abc123", "name": "service-name", "version": "1.0" } }, "user": {}, "tags": {}, "custom": { } }, "sync": true, "span_count": { "started": 0 }, "outcome": "unknown", "faas": { "coldstart": false, "execution": "2e13b309-23e1-417f-8bf7-074fc96bc683", "trigger": { "request_id": "FuH2Cir_vHcEMUA=", "type": "http" } }, "sample_rate": 1 } }
 `)
-	agentData := apmproxy.AgentData{Data: benchBody, ContentEncoding: ""}
+	agentData := apmproxy.APMData{Data: benchBody, ContentEncoding: ""}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/apmproxy/batch.go
+++ b/apmproxy/batch.go
@@ -1,0 +1,70 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package apmproxy
+
+import "errors"
+
+// ErrBatchFull signfies that the batch has reached full
+// capacity and cannot accept more entires.
+var ErrBatchFull = errors.New("batch is full")
+
+// BatchData represents a batch of data without metadata
+// that will be sent to APMServer. BatchData is not safe
+// concurrent access.
+type BatchData struct {
+	agentData []APMData
+	maxSize   int
+}
+
+// NewBatch creates a new BatchData which can accept a
+// maximum number of entires as specified by the argument
+func NewBatch(maxSize int) *BatchData {
+	return &BatchData{
+		maxSize:   maxSize,
+		agentData: make([]APMData, 0, maxSize),
+	}
+}
+
+// Add adds a new entry to the batch. Returns ErrBatchFull
+// if batch has reached it's maximum size.
+func (b *BatchData) Add(d APMData) error {
+	if len(b.agentData) >= b.maxSize {
+		return ErrBatchFull
+	}
+
+	b.agentData = append(b.agentData, d)
+	return nil
+}
+
+// Size return the number of entries in batch.
+func (b *BatchData) Size() int {
+	return len(b.agentData)
+}
+
+// ShouldFlush indicates when a batch is ready for flush.
+// A batch is marked as ready for flush once it reaches
+// 90% of its max size.
+func (b *BatchData) ShouldFlush() bool {
+	return len(b.agentData) >= int(float32(b.maxSize)*0.9)
+}
+
+// Reset resets the batch to prepare for new set of data
+func (b *BatchData) Reset() {
+	b.agentData = nil
+	b.agentData = make([]APMData, 0, b.maxSize)
+}

--- a/apmproxy/client.go
+++ b/apmproxy/client.go
@@ -65,6 +65,9 @@ type Client struct {
 
 	flushMutex sync.Mutex
 	flushCh    chan struct{}
+
+	metadataMutex sync.RWMutex
+	metadata      []byte
 }
 
 func NewClient(opts ...Option) (*Client, error) {

--- a/apmproxy/client.go
+++ b/apmproxy/client.go
@@ -52,7 +52,7 @@ const (
 type Client struct {
 	mu                sync.RWMutex
 	bufferPool        sync.Pool
-	DataChannel       chan AgentData
+	DataChannel       chan APMData
 	client            *http.Client
 	Status            Status
 	ReconnectionCount int
@@ -72,7 +72,7 @@ func NewClient(opts ...Option) (*Client, error) {
 		bufferPool: sync.Pool{New: func() interface{} {
 			return &bytes.Buffer{}
 		}},
-		DataChannel: make(chan AgentData, defaultAgentBufferSize),
+		DataChannel: make(chan APMData, defaultAgentBufferSize),
 		client: &http.Client{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
 		},

--- a/apmproxy/client.go
+++ b/apmproxy/client.go
@@ -66,8 +66,9 @@ type Client struct {
 	flushMutex sync.Mutex
 	flushCh    chan struct{}
 
-	metadataMutex sync.RWMutex
-	metadata      []byte
+	metadataAvailable chan<- struct{}
+	metadataMutex     sync.RWMutex
+	metadata          []byte
 }
 
 func NewClient(opts ...Option) (*Client, error) {

--- a/apmproxy/client_test.go
+++ b/apmproxy/client_test.go
@@ -18,8 +18,9 @@
 package apmproxy_test
 
 import (
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"testing"
+
+	"github.com/elastic/apm-aws-lambda/apmproxy"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -34,10 +35,7 @@ func TestClient(t *testing.T) {
 			expectedErr: true,
 		},
 		"missing base url": {
-			opts: []apmproxy.Option{
-				apmproxy.WithURL(""),
-				apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
-			},
+			opts:        []apmproxy.Option{},
 			expectedErr: true,
 		},
 		"missing logger": {
@@ -46,10 +44,18 @@ func TestClient(t *testing.T) {
 			},
 			expectedErr: true,
 		},
+		"missing metadata indicator": {
+			opts: []apmproxy.Option{
+				apmproxy.WithURL("https://example.com"),
+				apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+			},
+			expectedErr: true,
+		},
 		"valid": {
 			opts: []apmproxy.Option{
 				apmproxy.WithURL("https://example.com"),
 				apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+				apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 			},
 		},
 	}

--- a/apmproxy/metadata.go
+++ b/apmproxy/metadata.go
@@ -25,10 +25,6 @@ import (
 	"io"
 )
 
-type MetadataContainer struct {
-	Metadata []byte
-}
-
 // ProcessMetadata return a byte array containing the Metadata marshaled in JSON
 // In case we want to update the Metadata values, usage of https://github.com/tidwall/sjson is advised
 func ProcessMetadata(data APMData) ([]byte, error) {

--- a/apmproxy/metadata.go
+++ b/apmproxy/metadata.go
@@ -31,7 +31,7 @@ type MetadataContainer struct {
 
 // ProcessMetadata return a byte array containing the Metadata marshaled in JSON
 // In case we want to update the Metadata values, usage of https://github.com/tidwall/sjson is advised
-func ProcessMetadata(data AgentData) ([]byte, error) {
+func ProcessMetadata(data APMData) ([]byte, error) {
 	uncompressedData, err := GetUncompressedBytes(data.Data, data.ContentEncoding)
 	if err != nil {
 		return nil, fmt.Errorf("error uncompressing agent data for metadata extraction: %w", err)

--- a/apmproxy/metadata_test.go
+++ b/apmproxy/metadata_test.go
@@ -21,9 +21,10 @@ import (
 	"bytes"
 	"compress/gzip"
 	"compress/zlib"
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"io"
 	"testing"
+
+	"github.com/elastic/apm-aws-lambda/apmproxy"
 
 	"github.com/stretchr/testify/require"
 )
@@ -133,7 +134,7 @@ func Test_processMetadata(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			agentData := apmproxy.AgentData{Data: tc.data(), ContentEncoding: tc.encodingType}
+			agentData := apmproxy.APMData{Data: tc.data(), ContentEncoding: tc.encodingType}
 			extractedMetadata, err := apmproxy.ProcessMetadata(agentData)
 
 			if tc.expectError != nil {
@@ -167,7 +168,7 @@ func BenchmarkProcessMetadata(b *testing.B) {
 	}
 
 	for _, bench := range benchmarks {
-		agentData := apmproxy.AgentData{Data: bench.body, ContentEncoding: ""}
+		agentData := apmproxy.APMData{Data: bench.body, ContentEncoding: ""}
 
 		b.Run(bench.name, func(b *testing.B) {
 			b.ReportAllocs()

--- a/apmproxy/option.go
+++ b/apmproxy/option.go
@@ -91,3 +91,11 @@ func WithMetadataAvailableIndicator(ch chan<- struct{}) Option {
 		c.metadataAvailable = ch
 	}
 }
+
+// WithMaxBatchSize configures the maximum number of events in the
+// payload sent to APM Server.
+func WithMaxBatchSize(batchSize int) Option {
+	return func(c *Client) {
+		c.maxBatchSize = batchSize
+	}
+}

--- a/apmproxy/option.go
+++ b/apmproxy/option.go
@@ -74,7 +74,7 @@ func WithSendStrategy(strategy SendStrategy) Option {
 // WithAgentDataBufferSize sets the agent data buffer size.
 func WithAgentDataBufferSize(size int) Option {
 	return func(c *Client) {
-		c.DataChannel = make(chan AgentData, size)
+		c.DataChannel = make(chan APMData, size)
 	}
 }
 

--- a/apmproxy/option.go
+++ b/apmproxy/option.go
@@ -83,3 +83,11 @@ func WithLogger(logger *zap.SugaredLogger) Option {
 		c.logger = logger
 	}
 }
+
+// WithMetadataAvailableIndicator configures a channel
+// which will broadcast metadata available event on close
+func WithMetadataAvailableIndicator(ch chan<- struct{}) Option {
+	return func(c *Client) {
+		c.metadataAvailable = ch
+	}
+}

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -39,7 +39,9 @@ const (
 	Lambda APMDataType = "lambda"
 )
 
-// APMData represents data to be sent to APMServer
+// APMData represents data to be sent to APMServer. `Agent` type
+// data will have `metadata` as ndjson whereas `lambda` type data
+// will be without metadata.
 type APMData struct {
 	Data            []byte
 	Type            APMDataType

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -29,12 +29,24 @@ import (
 	"time"
 )
 
-type AgentData struct {
+// APMDataType represents source of APMData
+type APMDataType string
+
+const (
+	// Agent data type represents APMData collected from APM agents
+	Agent APMDataType = "agent"
+	// Lambda data type represents APMData collected from logs API
+	Lambda APMDataType = "lambda"
+)
+
+// APMData represents data to be sent to APMServer
+type APMData struct {
 	Data            []byte
+	Type            APMDataType
 	ContentEncoding string
 }
 
-// StartHttpServer starts the server listening for APM agent data.
+// StartReceiver starts the server listening for APM agent data.
 func (c *Client) StartReceiver() error {
 	mux := http.NewServeMux()
 
@@ -123,8 +135,9 @@ func (c *Client) handleIntakeV2Events() func(w http.ResponseWriter, r *http.Requ
 
 		agentFlushed := r.URL.Query().Get("flushed") == "true"
 
-		agentData := AgentData{
+		agentData := APMData{
 			Data:            rawBytes,
+			Type:            Agent,
 			ContentEncoding: r.Header.Get("Content-Encoding"),
 		}
 

--- a/apmproxy/receiver_test.go
+++ b/apmproxy/receiver_test.go
@@ -19,7 +19,6 @@ package apmproxy_test
 
 import (
 	"bytes"
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"io"
 	"net"
 	"net/http"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/elastic/apm-aws-lambda/apmproxy"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -57,6 +58,7 @@ func TestInfoProxy(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -102,6 +104,7 @@ func TestInfoProxyErrorStatusCode(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -140,6 +143,7 @@ func Test_handleInfoRequest(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 
@@ -180,6 +184,7 @@ func Test_handleIntakeV2EventsQueryParam(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	require.NoError(t, apmClient.StartReceiver())
@@ -222,6 +227,7 @@ func Test_handleIntakeV2EventsNoQueryParam(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	require.NoError(t, apmClient.StartReceiver())
@@ -265,6 +271,7 @@ func Test_handleIntakeV2EventsQueryParamEmptyData(t *testing.T) {
 		apmproxy.WithReceiverAddress(":1234"),
 		apmproxy.WithReceiverTimeout(15*time.Second),
 		apmproxy.WithLogger(zaptest.NewLogger(t).Sugar()),
+		apmproxy.WithMetadataAvailableIndicator(make(chan struct{})),
 	)
 	require.NoError(t, err)
 	require.NoError(t, apmClient.StartReceiver())

--- a/app/app.go
+++ b/app/app.go
@@ -67,6 +67,7 @@ func New(ctx context.Context, opts ...ConfigOption) (*App, error) {
 		return nil, err
 	}
 
+	metadataAvailable := make(chan struct{})
 	app.extensionClient = extension.NewClient(c.awsLambdaRuntimeAPI, app.logger)
 
 	if !c.disableLogsAPI {
@@ -86,6 +87,7 @@ func New(ctx context.Context, opts ...ConfigOption) (*App, error) {
 			logsapi.WithLogBuffer(100),
 			logsapi.WithLogger(app.logger),
 			logsapi.WithSubscriptionTypes(subscriptionLogStreams...),
+			logsapi.WithMetadataAvailableIndicator(metadataAvailable),
 		)
 		if err != nil {
 			return nil, err
@@ -132,6 +134,7 @@ func New(ctx context.Context, opts ...ConfigOption) (*App, error) {
 		apmproxy.WithLogger(app.logger),
 		apmproxy.WithAPIKey(apmServerAPIKey),
 		apmproxy.WithSecretToken(apmServerSecretToken),
+		apmproxy.WithMetadataAvailableIndicator(metadataAvailable),
 	)
 
 	ac, err := apmproxy.NewClient(apmOpts...)

--- a/app/config.go
+++ b/app/config.go
@@ -27,6 +27,7 @@ type appConfig struct {
 	enableFunctionLogSubscription bool
 	logLevel                      string
 	logsapiAddr                   string
+	metadataAvailable             chan struct{}
 }
 
 // ConfigOption is used to configure the lambda extension
@@ -83,5 +84,13 @@ func WithLogsapiAddress(s string) ConfigOption {
 func WithAWSConfig(awsConfig aws.Config) ConfigOption {
 	return func(c *appConfig) {
 		c.awsConfig = awsConfig
+	}
+}
+
+// WithMetadataAvailableIndicator configures a channel which should
+// be closed when metadata is available after parsing agent data.
+func WithMetadataAvailableIndicator(ch chan struct{}) ConfigOption {
+	return func(c *appConfig) {
+		c.metadataAvailable = ch
 	}
 }

--- a/app/run.go
+++ b/app/run.go
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"github.com/elastic/apm-aws-lambda/extension"
 )
 
@@ -82,9 +81,6 @@ func (app *App) Run(ctx context.Context) error {
 
 	// The previous event id is used to validate the received Lambda metrics
 	var prevEvent *extension.NextEventResponse
-	// This data structure contains metadata tied to the current Lambda instance. If empty, it is populated once for each
-	// active Lambda environment
-	metadataContainer := apmproxy.MetadataContainer{}
 
 	for {
 		select {
@@ -96,7 +92,7 @@ func (app *App) Run(ctx context.Context) error {
 			// Use a wait group to ensure the background go routine sending to the APM server
 			// completes before signaling that the extension is ready for the next invocation.
 			var backgroundDataSendWg sync.WaitGroup
-			event, err := app.processEvent(ctx, &backgroundDataSendWg, prevEvent, &metadataContainer)
+			event, err := app.processEvent(ctx, &backgroundDataSendWg, prevEvent)
 			if err != nil {
 				return err
 			}
@@ -120,7 +116,6 @@ func (app *App) processEvent(
 	ctx context.Context,
 	backgroundDataSendWg *sync.WaitGroup,
 	prevEvent *extension.NextEventResponse,
-	metadataContainer *apmproxy.MetadataContainer,
 ) (*extension.NextEventResponse, error) {
 	// Reset flush state for future events.
 	defer app.apmClient.ResetFlush()
@@ -159,7 +154,7 @@ func (app *App) processEvent(
 	backgroundDataSendWg.Add(1)
 	go func() {
 		defer backgroundDataSendWg.Done()
-		if err := app.apmClient.ForwardApmData(invocationCtx, metadataContainer); err != nil {
+		if err := app.apmClient.ForwardApmData(invocationCtx); err != nil {
 			app.logger.Error(err)
 		}
 	}()
@@ -174,7 +169,6 @@ func (app *App) processEvent(
 				event.RequestID,
 				event.InvokedFunctionArn,
 				app.apmClient,
-				metadataContainer,
 				runtimeDone,
 				prevEvent,
 			); err != nil {

--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	logsAPIBaseURL           string
 	logsAPISubscriptionTypes []SubscriptionType
 	logsChannel              chan LogEvent
+	metadataAvailable        <-chan struct{}
 	listenerAddr             string
 	server                   *http.Server
 	logger                   *zap.SugaredLogger
@@ -69,7 +70,7 @@ func NewClient(opts ...ClientOption) (*Client, error) {
 	}
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/", handleLogEventsRequest(c.logger, c.logsChannel))
+	mux.HandleFunc("/", handleLogEventsRequest(c.logger, c.logsChannel, c.metadataAvailable))
 
 	c.server.Handler = mux
 

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -60,7 +60,6 @@ func (lc *Client) ProcessLogs(
 	requestID string,
 	invokedFnArn string,
 	apmClient *apmproxy.Client,
-	metadataContainer *apmproxy.MetadataContainer,
 	runtimeDoneSignal chan struct{},
 	prevEvent *extension.NextEventResponse,
 ) error {
@@ -89,7 +88,7 @@ func (lc *Client) ProcessLogs(
 			case PlatformReport:
 				if prevEvent != nil && logEvent.Record.RequestID == prevEvent.RequestID {
 					lc.logger.Debug("Received platform report for the previous function invocation")
-					processedMetrics, err := ProcessPlatformReport(metadataContainer, prevEvent, logEvent)
+					processedMetrics, err := ProcessPlatformReport(prevEvent, logEvent)
 					if err != nil {
 						lc.logger.Errorf("Error processing Lambda platform metrics : %v", err)
 					} else {
@@ -100,11 +99,8 @@ func (lc *Client) ProcessLogs(
 					lc.logger.Debug("Log API runtimeDone event request id didn't match")
 				}
 			case FunctionLog:
-				// TODO: @lahsivjar Buffer logs and send batches of data to APM-Server.
-				// Buffering should account for metadata being available before sending.
 				lc.logger.Debug("Received function log")
 				processedLog, err := ProcessFunctionLog(
-					metadataContainer,
 					platformStartReqID,
 					invokedFnArn,
 					logEvent,

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -33,6 +33,7 @@ const (
 	PlatformRuntimeDone LogEventType = "platform.runtimeDone"
 	PlatformFault       LogEventType = "platform.fault"
 	PlatformReport      LogEventType = "platform.report"
+	PlatformLogsDropped LogEventType = "platform.logsDropped"
 	PlatformStart       LogEventType = "platform.start"
 	PlatformEnd         LogEventType = "platform.end"
 	FunctionLog         LogEventType = "function"
@@ -90,7 +91,7 @@ func (lc *Client) ProcessLogs(
 					lc.logger.Debug("Received platform report for the previous function invocation")
 					processedMetrics, err := ProcessPlatformReport(prevEvent, logEvent)
 					if err != nil {
-						lc.logger.Errorf("Error processing Lambda platform metrics : %v", err)
+						lc.logger.Errorf("Error processing Lambda platform metrics: %v", err)
 					} else {
 						apmClient.EnqueueAPMData(processedMetrics)
 					}
@@ -98,6 +99,8 @@ func (lc *Client) ProcessLogs(
 					lc.logger.Warn("report event request id didn't match the previous event id")
 					lc.logger.Debug("Log API runtimeDone event request id didn't match")
 				}
+			case PlatformLogsDropped:
+				lc.logger.Warn("Logs dropped due to extension falling behind: %v", logEvent.Record)
 			case FunctionLog:
 				lc.logger.Debug("Received function log")
 				processedLog, err := ProcessFunctionLog(

--- a/logsapi/functionlogs.go
+++ b/logsapi/functionlogs.go
@@ -18,8 +18,6 @@
 package logsapi
 
 import (
-	"errors"
-
 	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"go.elastic.co/apm/v2/model"
 	"go.elastic.co/fastjson"
@@ -88,15 +86,10 @@ func (lc logContainer) MarshalFastJSON(json *fastjson.Writer) error {
 // ProcessFunctionLog consumes agent metadata and log event from Lambda
 // logs API to create a payload for APM server.
 func ProcessFunctionLog(
-	metadataContainer *apmproxy.MetadataContainer,
 	requestID string,
 	invokedFnArn string,
 	log LogEvent,
 ) (apmproxy.APMData, error) {
-	if metadataContainer == nil || len(metadataContainer.Metadata) == 0 {
-		return apmproxy.APMData{}, errors.New("metadata is required")
-	}
-
 	lc := logContainer{
 		Log: &logLine{
 			Timestamp: model.Time(log.Time),
@@ -114,11 +107,8 @@ func ProcessFunctionLog(
 		return apmproxy.APMData{}, err
 	}
 
-	capacity := len(metadataContainer.Metadata) + jsonWriter.Size() + 1
-	logData := make([]byte, len(metadataContainer.Metadata), capacity)
-	copy(logData, metadataContainer.Metadata)
-
-	logData = append(logData, '\n')
-	logData = append(logData, jsonWriter.Bytes()...)
-	return apmproxy.APMData{Type: apmproxy.Lambda, Data: logData}, nil
+	return apmproxy.APMData{
+		Type: apmproxy.Lambda,
+		Data: jsonWriter.Bytes(),
+	}, nil
 }

--- a/logsapi/functionlogs.go
+++ b/logsapi/functionlogs.go
@@ -92,9 +92,9 @@ func ProcessFunctionLog(
 	requestID string,
 	invokedFnArn string,
 	log LogEvent,
-) (apmproxy.AgentData, error) {
+) (apmproxy.APMData, error) {
 	if metadataContainer == nil || len(metadataContainer.Metadata) == 0 {
-		return apmproxy.AgentData{}, errors.New("metadata is required")
+		return apmproxy.APMData{}, errors.New("metadata is required")
 	}
 
 	lc := logContainer{
@@ -111,7 +111,7 @@ func ProcessFunctionLog(
 
 	var jsonWriter fastjson.Writer
 	if err := lc.MarshalFastJSON(&jsonWriter); err != nil {
-		return apmproxy.AgentData{}, err
+		return apmproxy.APMData{}, err
 	}
 
 	capacity := len(metadataContainer.Metadata) + jsonWriter.Size() + 1
@@ -120,5 +120,5 @@ func ProcessFunctionLog(
 
 	logData = append(logData, '\n')
 	logData = append(logData, jsonWriter.Bytes()...)
-	return apmproxy.AgentData{Data: logData}, nil
+	return apmproxy.APMData{Type: apmproxy.Lambda, Data: logData}, nil
 }

--- a/logsapi/functionlogs_test.go
+++ b/logsapi/functionlogs_test.go
@@ -50,5 +50,6 @@ func TestProcessFunctionLog(t *testing.T) {
 	apmData, err := ProcessFunctionLog(metadataContainer, reqID, invokedFnArn, event)
 
 	require.NoError(t, err)
+	assert.Equal(t, apmproxy.Lambda, apmData.Type)
 	assert.Equal(t, expectedData, string(apmData.Data))
 }

--- a/logsapi/metrics.go
+++ b/logsapi/metrics.go
@@ -18,7 +18,6 @@
 package logsapi
 
 import (
-	"errors"
 	"math"
 
 	"github.com/elastic/apm-aws-lambda/apmproxy"
@@ -63,12 +62,7 @@ func (mc MetricsContainer) MarshalFastJSON(json *fastjson.Writer) error {
 	return nil
 }
 
-func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.APMData, error) {
-
-	if metadataContainer == nil || len(metadataContainer.Metadata) == 0 {
-		return apmproxy.APMData{}, errors.New("metadata is not populated")
-	}
-
+func ProcessPlatformReport(functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.APMData, error) {
 	metricsContainer := MetricsContainer{
 		Metrics: &model.Metrics{},
 	}
@@ -106,11 +100,8 @@ func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functi
 		return apmproxy.APMData{}, err
 	}
 
-	capacity := len(metadataContainer.Metadata) + jsonWriter.Size() + 1 // 1 for newline
-	metricsData := make([]byte, len(metadataContainer.Metadata), capacity)
-	copy(metricsData, metadataContainer.Metadata)
-
-	metricsData = append(metricsData, []byte("\n")...)
-	metricsData = append(metricsData, jsonWriter.Bytes()...)
-	return apmproxy.APMData{Type: apmproxy.Lambda, Data: metricsData}, nil
+	return apmproxy.APMData{
+		Type: apmproxy.Lambda,
+		Data: jsonWriter.Bytes(),
+	}, nil
 }

--- a/logsapi/metrics.go
+++ b/logsapi/metrics.go
@@ -63,10 +63,10 @@ func (mc MetricsContainer) MarshalFastJSON(json *fastjson.Writer) error {
 	return nil
 }
 
-func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.AgentData, error) {
+func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.APMData, error) {
 
 	if metadataContainer == nil || len(metadataContainer.Metadata) == 0 {
-		return apmproxy.AgentData{}, errors.New("metadata is not populated")
+		return apmproxy.APMData{}, errors.New("metadata is not populated")
 	}
 
 	metricsContainer := MetricsContainer{
@@ -103,7 +103,7 @@ func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functi
 
 	var jsonWriter fastjson.Writer
 	if err := metricsContainer.MarshalFastJSON(&jsonWriter); err != nil {
-		return apmproxy.AgentData{}, err
+		return apmproxy.APMData{}, err
 	}
 
 	capacity := len(metadataContainer.Metadata) + jsonWriter.Size() + 1 // 1 for newline
@@ -112,5 +112,5 @@ func ProcessPlatformReport(metadataContainer *apmproxy.MetadataContainer, functi
 
 	metricsData = append(metricsData, []byte("\n")...)
 	metricsData = append(metricsData, jsonWriter.Bytes()...)
-	return apmproxy.AgentData{Data: metricsData}, nil
+	return apmproxy.APMData{Type: apmproxy.Lambda, Data: metricsData}, nil
 }

--- a/logsapi/option.go
+++ b/logsapi/option.go
@@ -55,3 +55,11 @@ func WithSubscriptionTypes(types ...SubscriptionType) ClientOption {
 		c.logsAPISubscriptionTypes = types
 	}
 }
+
+// WithMetadataAvailableIndicator configures a channel
+// which will broadcast metadata available event on close
+func WithMetadataAvailableIndicator(ch <-chan struct{}) ClientOption {
+	return func(c *Client) {
+		c.metadataAvailable = ch
+	}
+}

--- a/logsapi/route_handlers.go
+++ b/logsapi/route_handlers.go
@@ -25,8 +25,22 @@ import (
 	"go.uber.org/zap"
 )
 
-func handleLogEventsRequest(logger *zap.SugaredLogger, logsChannel chan LogEvent) func(w http.ResponseWriter, r *http.Request) {
+func handleLogEventsRequest(
+	logger *zap.SugaredLogger,
+	logsChannel chan LogEvent,
+	metadataAvailable <-chan struct{},
+) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-metadataAvailable:
+		case <-time.After(100 * time.Millisecond):
+			// Without metadata the events cannot be processed
+			// thus we indicate lambda to keep the buffer
+			logger.Warnf("Metadata unavailable, signaling lambda to buffer log events")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
 		var logEvents []LogEvent
 		if err := json.NewDecoder(r.Body).Decode(&logEvents); err != nil {
 			logger.Errorf("Error unmarshalling log events: %+v", err)

--- a/logsapi/subscribe.go
+++ b/logsapi/subscribe.go
@@ -86,8 +86,8 @@ func (lc *Client) subscribe(types []SubscriptionType, extensionID string, uri st
 		LogTypes:      types,
 		BufferingCfg: BufferingCfg{
 			MaxItems:  10000,
-			MaxBytes:  262144,
-			TimeoutMS: 25,
+			MaxBytes:  1024 * 1024,
+			TimeoutMS: 100,
 		},
 		Destination: Destination{
 			Protocol:   "HTTP",

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 		app.WithLambdaRuntimeAPI(os.Getenv("AWS_LAMBDA_RUNTIME_API")),
 		app.WithLogLevel(os.Getenv("ELASTIC_APM_LOG_LEVEL")),
 		app.WithAWSConfig(cfg),
+		app.WithMetadataAvailableIndicator(make(chan struct{})),
 	}
 
 	captureLogs, err := strconv.ParseBool(os.Getenv("ELASTIC_APM_LAMBDA_CAPTURE_LOGS"))


### PR DESCRIPTION
This PR makes introduces 2 features for handling events generated by Logs API:

1. Events generated from lambda logs are batched. The batch is bounded by age and size.
2. Pushback on Lambda logs API if metadata from agents is not available. Due to this behavior, the lifecycle of the extension is also affected since we push back on all log events from the Logs API including the `platform.runtimeDone`. In case lambda Logs API drops logs due to resource constraints generated by our pushback, a new event `platform.logsDropped` is published which we log from the extension. Retention of this log event by the logs API is not clear, it might be possible that this log event is also dropped but it hasn't occurred in any of my tests so far.

Closes #311 