### PR TITLE
build: add smoke test log and build folder to gitignore

### DIFF
--- a/tf/.gitignore
+++ b/tf/.gitignore
@@ -2,3 +2,9 @@
 
 *.tfstate
 *.tfstate.*
+
+# smoke tests
+response.json
+tf.log
+
+builds/


### PR DESCRIPTION
smoke tests are creating build folder and log files.

Add them to gitignore