### PR TITLE
test: fix smoke test script invoking function on the wrong region

### DIFF
--- a/tf/output.tf
+++ b/tf/output.tf
@@ -14,3 +14,8 @@ output "elasticsearch_password" {
   description = "The Elasticsearch password"
   sensitive   = true
 }
+
+output "aws_region" {
+  value       = var.aws_region
+  description = "The AWS region"
+}

--- a/tf/test.sh
+++ b/tf/test.sh
@@ -15,9 +15,11 @@ echo "-> Creating the underlying infrastructure..."
 terraform init | tee tf.log
 terraform apply -auto-approve | tee -a tf.log
 
+AWS_REGION=$(terraform output -raw aws_region)
+
 echo "-> Calling the lambda function..."
-aws lambda invoke --region=eu-central-1 --function-name smoke-testing-test response.json
-aws lambda invoke --region=eu-central-1 --function-name smoke-testing-test response.json
+aws lambda invoke --region="${AWS_REGION}" --function-name smoke-testing-test response.json
+aws lambda invoke --region="${AWS_REGION}" --function-name smoke-testing-test response.json
 
 echo "-> Waiting for the agent documents to be indexed in Elasticsearch..."
 


### PR DESCRIPTION
Configurable regions are supported by the terraform script bu the bash script used for smoke testing is only invoking the lambda function in the default region (eu-central-1).
Add a new output variable to retrieve the aws region in the shell script and update the lambda invocation.