### PR TITLE
build: make ess version configurable

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -10,6 +10,7 @@ module "ec_deployment" {
   apm_server_pprof       = false
   region                 = var.ess_region
   deployment_template    = var.ess_deployment_template
+  stack_version          = var.ess_version
 }
 
 module "lambda_function" {

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -21,3 +21,9 @@ variable "ess_deployment_template" {
   description = "Elastic Cloud deployment template"
   default     = "gcp-compute-optimized"
 }
+
+variable "ess_version" {
+  type        = string
+  description = "ess version"
+  default     = "8.[0-9]?([0-9]).[0-9]?([0-9])$"
+}


### PR DESCRIPTION
The terraform script used for smoke testing was defaulting to the latest version of ess.
Because we want to test on stable versions and allow people to reuse the script to provision and test the dev environment, add a variable to make ess version configurable and default to the latest 8.x version.