### PR TITLE
build: add SKIP_DESTROY env option

### DIFF
--- a/tf/test.sh
+++ b/tf/test.sh
@@ -6,7 +6,7 @@ export TF_IN_AUTOMATION=1
 export TF_CLI_ARGS=-no-color
 
 cleanup() {
-  terraform destroy -auto-approve >> tf.log
+  [ "$SKIP_DESTROY" != "1" ]; terraform destroy -auto-approve >> tf.log
 }
 
 trap "cleanup" EXIT


### PR DESCRIPTION
The terraform script can only be used for smoke testing as it is, since the environment is destroyed once the script exits. To allow reuse, add a SKIP_DESTROY env variable to skip the cleanup process and allow to use the script for provisioning.