### PR TITLE
release: delete layer before publishing

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -154,6 +154,19 @@ pipeline {
                   }
                 }
               }
+              stage('DeletePreviousLayer') {
+                steps {
+                  withGithubNotify(context: "Delete-Layer-${PLATFORM}") {
+                    withGoEnv(){
+                      withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', forceInstallation: true, version: '2.4.10') {
+                        dir("${BASE_DIR}"){
+                          cmd(label: 'make delete-in-all-aws-regions', script: 'make delete-in-all-aws-regions', returnStatus: true)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
               stage('PublishLayer') {
                 steps {
                   withGithubNotify(context: "Publish-Layer-${PLATFORM}") {

--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,9 @@ delete-in-all-aws-regions: validate-layer-name get-all-aws-regions
 # Delete the given LAYER in the given AWS region, it won't fail
 delete: validate-layer-name validate-aws-default-region
 	@aws lambda \
-		--output json \
 		delete-layer-version \
 		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
-		--version-number 1 || true
+		--version-number 1 || echo "delete-layer-version $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) for $${AWS_DEFAULT_REGION} could not be found"
 
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,22 @@ publish: validate-layer-name validate-aws-default-region
 		--license "Apache-2.0" \
 		--zip-file "fileb://./bin/extension.zip"
 
+# Delete the given LAYER in all the AWS regions
+delete-in-all-aws-regions: validate-layer-name get-all-aws-regions
+	@mkdir -p $(AWS_FOLDER)
+	@while read AWS_DEFAULT_REGION; do \
+		echo "delete '$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)' in $${AWS_DEFAULT_REGION}"; \
+		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) delete; \
+	done <.regions
+
+# Delete the given LAYER in the given AWS region, it won't fail
+delete: validate-layer-name validate-aws-default-region
+	@aws lambda \
+		--output json \
+		delete-layer-version \
+		--layer-name "$(ELASTIC_LAYER_NAME)-$(ARCHITECTURE)" \
+		--version-number 1 || true
+
 # Grant public access to the given LAYER in the given AWS region
 grant-public-layer-access: validate-layer-name validate-aws-default-region
 	@echo "[debug] $(ELASTIC_LAYER_NAME)-$(ARCHITECTURE) with version: $$($(MAKE) -s --no-print-directory get-version)"


### PR DESCRIPTION
### What

Ensure the lambda is always pointing to the version 1.

### Why

Version and releases will be predictable. 

### Further details

@AlexanderWert provided some feedback in the past:

> One think that I observed is, that it would be nice and less confusion for the users if all the Layers we are publishing would always have version 1 as the layer version. (Sometimes it's not, when something fails and we retrigger publishing).
Do you think we could add a layer deletion step (if a layer with a certain name already exists) before we do the publishing? In this way we could guarantee that the layer ARNs always have the suffix / version 1
I think this would improve experience a lot, since we then won't need to link to the GitHub table but could provide a generic pattern and maybe even writing a small HTML / Javascript tool embedded in the docs to pick the right ARNhis will ensure the version is always 1 per release

### Test

- [x] Verify it works as expected 


#### Use case: delete-in-all-aws-regions doesn't fail when no versions available


```bash
$ AWS_SECRET_ACCESS_KEY="*" \
AWS_ACCESS_KEY_ID="*" \
ELASTIC_LAYER_NAME=v1v-lambda-test-0-0-1 \
BRANCH_NAME=duplicated-entries \
make  delete-in-all-aws-regions                       

delete 'v1v-lambda-test-0-0-1-x86_64' in af-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-north-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-3
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-2
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-3
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-2
delete 'v1v-lambda-test-0-0-1-x86_64' in me-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-1
delete 'v1v-lambda-test-0-0-1-x86_64' in sa-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ca-central-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-2
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-3
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-central-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-east-2
delete 'v1v-lambda-test-0-0-1-x86_64' in us-west-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-west-2
$ echo $?
0
```

#### Use case: delete-in-all-aws-regions deletes all the previous versions


```bash
$ AWS_SECRET_ACCESS_KEY="*****" \
AWS_ACCESS_KEY_ID="******" \
ELASTIC_LAYER_NAME=v1v-lambda-test-0-0-1 \
BRANCH_NAME=duplicated-entries \
make  delete-in-all-aws-regions                       

delete 'v1v-lambda-test-0-0-1-x86_64' in af-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-north-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-3
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-2
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-west-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-3
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-2
delete 'v1v-lambda-test-0-0-1-x86_64' in me-south-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-northeast-1
delete 'v1v-lambda-test-0-0-1-x86_64' in sa-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ca-central-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-1
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-2
delete 'v1v-lambda-test-0-0-1-x86_64' in ap-southeast-3
delete 'v1v-lambda-test-0-0-1-x86_64' in eu-central-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-east-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-east-2
delete 'v1v-lambda-test-0-0-1-x86_64' in us-west-1
delete 'v1v-lambda-test-0-0-1-x86_64' in us-west-2
$ echo $?
0
...
```