### PR TITLE
Remove usage of APMData within logsapi

### DIFF
--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -48,7 +48,7 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 		return nil
 	}
 
-	var lambdaDataChan chan APMData
+	var lambdaDataChan chan []byte
 	for {
 		select {
 		case <-ctx.Done():
@@ -339,13 +339,13 @@ func (c *Client) forwardAgentData(ctx context.Context, apmData APMData) error {
 	return c.PostToApmServer(ctx, apmData)
 }
 
-func (c *Client) forwardLambdaData(ctx context.Context, apmData APMData) error {
+func (c *Client) forwardLambdaData(ctx context.Context, data []byte) error {
 	if c.batch == nil {
 		// This state is not possible since we start processing lambda
 		// logs only after metadata is available and batch is created.
 		return errors.New("unexpected state, metadata not yet set")
 	}
-	if err := c.batch.Add(apmData); err != nil {
+	if err := c.batch.Add(data); err != nil {
 		c.logger.Warnf("Dropping data due to error: %v", err)
 	}
 	if c.batch.ShouldShip() {

--- a/apmproxy/apmserver_test.go
+++ b/apmproxy/apmserver_test.go
@@ -648,9 +648,7 @@ func TestForwardApmData(t *testing.T) {
 			// Wait for batch age to make sure the batch is mature to be sent
 			time.Sleep(maxBatchAge + time.Millisecond)
 		}
-		apmClient.LambdaDataChannel <- apmproxy.APMData{
-			Data: []byte(lambdaData),
-		}
+		apmClient.LambdaDataChannel <- []byte(lambdaData)
 		expected.WriteByte('\n')
 		expected.WriteString(lambdaData)
 	}
@@ -698,9 +696,7 @@ func BenchmarkFlushAPMData(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		apmClient.AgentDataChannel <- agentAPMData
 		for j := 0; j < 99; j++ {
-			apmClient.LambdaDataChannel <- apmproxy.APMData{
-				Data: []byte("this is test log"),
-			}
+			apmClient.LambdaDataChannel <- []byte("this is test log")
 		}
 		apmClient.FlushAPMData(context.Background())
 	}

--- a/apmproxy/batch.go
+++ b/apmproxy/batch.go
@@ -62,17 +62,14 @@ func NewBatch(maxSize int, maxAge time.Duration, metadata []byte) *BatchData {
 
 // Add adds a new entry to the batch. Returns ErrBatchFull
 // if batch has reached its maximum size.
-func (b *BatchData) Add(d APMData) error {
+func (b *BatchData) Add(d []byte) error {
 	if b.count == b.maxSize {
 		return ErrBatchFull
-	}
-	if d.ContentEncoding != "" {
-		return ErrInvalidEncoding
 	}
 	if err := b.buf.WriteByte('\n'); err != nil {
 		return err
 	}
-	if _, err := b.buf.Write(d.Data); err != nil {
+	if _, err := b.buf.Write(d); err != nil {
 		return err
 	}
 	if b.count == 0 {

--- a/apmproxy/batch_test.go
+++ b/apmproxy/batch_test.go
@@ -31,19 +31,19 @@ func TestAdd(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		b := NewBatch(1, time.Hour, []byte(metadata))
 
-		assert.NoError(t, b.Add(APMData{}))
+		assert.NoError(t, b.Add([]byte{}))
 	})
 	t.Run("full", func(t *testing.T) {
 		b := NewBatch(1, time.Hour, []byte(metadata))
-		require.NoError(t, b.Add(APMData{}))
+		require.NoError(t, b.Add([]byte{}))
 
-		assert.ErrorIs(t, ErrBatchFull, b.Add(APMData{}))
+		assert.ErrorIs(t, ErrBatchFull, b.Add([]byte{}))
 	})
 }
 
 func TestReset(t *testing.T) {
 	b := NewBatch(1, time.Hour, []byte(metadata))
-	require.NoError(t, b.Add(APMData{}))
+	require.NoError(t, b.Add([]byte{}))
 	require.Equal(t, 1, b.Count())
 	b.Reset()
 
@@ -57,7 +57,7 @@ func TestShouldShip_ReasonSize(t *testing.T) {
 	// Should flush at 90% full
 	for i := 0; i < 9; i++ {
 		assert.False(t, b.ShouldShip())
-		require.NoError(t, b.Add(APMData{}))
+		require.NoError(t, b.Add([]byte{}))
 	}
 
 	require.Equal(t, 9, b.Count())
@@ -68,7 +68,7 @@ func TestShouldShip_ReasonAge(t *testing.T) {
 	b := NewBatch(10, time.Second, []byte(metadata))
 
 	assert.False(t, b.ShouldShip())
-	require.NoError(t, b.Add(APMData{}))
+	require.NoError(t, b.Add([]byte{}))
 
 	time.Sleep(time.Second + time.Millisecond)
 

--- a/apmproxy/client.go
+++ b/apmproxy/client.go
@@ -56,7 +56,7 @@ type Client struct {
 	mu                sync.RWMutex
 	bufferPool        sync.Pool
 	AgentDataChannel  chan APMData
-	LambdaDataChannel chan APMData
+	LambdaDataChannel chan []byte
 	client            *http.Client
 	Status            Status
 	ReconnectionCount int
@@ -81,7 +81,7 @@ func NewClient(opts ...Option) (*Client, error) {
 			return &bytes.Buffer{}
 		}},
 		AgentDataChannel:  make(chan APMData, defaultAgentBufferSize),
-		LambdaDataChannel: make(chan APMData, defaultLambdaBufferSize),
+		LambdaDataChannel: make(chan []byte, defaultLambdaBufferSize),
 		client: &http.Client{
 			Transport: http.DefaultTransport.(*http.Transport).Clone(),
 		},

--- a/app/run.go
+++ b/app/run.go
@@ -168,7 +168,7 @@ func (app *App) processEvent(
 				invocationCtx,
 				event.RequestID,
 				event.InvokedFunctionArn,
-				app.apmClient,
+				app.apmClient.LambdaDataChannel,
 				runtimeDone,
 				prevEvent,
 			); err != nil {

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"github.com/elastic/apm-aws-lambda/extension"
 )
 
@@ -60,7 +59,7 @@ func (lc *Client) ProcessLogs(
 	ctx context.Context,
 	requestID string,
 	invokedFnArn string,
-	apmClient *apmproxy.Client,
+	dataChan chan []byte,
 	runtimeDoneSignal chan struct{},
 	prevEvent *extension.NextEventResponse,
 ) error {
@@ -94,7 +93,7 @@ func (lc *Client) ProcessLogs(
 						lc.logger.Errorf("Error processing Lambda platform metrics: %v", err)
 					} else {
 						select {
-						case apmClient.LambdaDataChannel <- processedMetrics:
+						case dataChan <- processedMetrics:
 						case <-ctx.Done():
 						}
 					}
@@ -115,7 +114,7 @@ func (lc *Client) ProcessLogs(
 					lc.logger.Errorf("Error processing function log : %v", err)
 				} else {
 					select {
-					case apmClient.LambdaDataChannel <- processedLog:
+					case dataChan <- processedLog:
 					case <-ctx.Done():
 					}
 				}

--- a/logsapi/functionlogs_test.go
+++ b/logsapi/functionlogs_test.go
@@ -42,8 +42,8 @@ func TestProcessFunctionLog(t *testing.T) {
 		reqID,
 	)
 
-	apmData, err := ProcessFunctionLog(reqID, invokedFnArn, event)
+	data, err := ProcessFunctionLog(reqID, invokedFnArn, event)
 
 	require.NoError(t, err)
-	assert.Equal(t, expectedData, string(apmData.Data))
+	assert.Equal(t, expectedData, string(data))
 }

--- a/logsapi/metrics.go
+++ b/logsapi/metrics.go
@@ -20,7 +20,6 @@ package logsapi
 import (
 	"math"
 
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"github.com/elastic/apm-aws-lambda/extension"
 	"go.elastic.co/apm/v2/model"
 	"go.elastic.co/fastjson"
@@ -62,7 +61,10 @@ func (mc MetricsContainer) MarshalFastJSON(json *fastjson.Writer) error {
 	return nil
 }
 
-func ProcessPlatformReport(functionData *extension.NextEventResponse, platformReport LogEvent) (apmproxy.APMData, error) {
+// ProcessPlatformReport processes the `platform.report` log line from lambda logs API and
+// returns a byte array containing the JSON body for the extracted platform metrics. A non
+// nil error is returned when marshaling of platform metrics into JSON fails.
+func ProcessPlatformReport(functionData *extension.NextEventResponse, platformReport LogEvent) ([]byte, error) {
 	metricsContainer := MetricsContainer{
 		Metrics: &model.Metrics{},
 	}
@@ -97,10 +99,8 @@ func ProcessPlatformReport(functionData *extension.NextEventResponse, platformRe
 
 	var jsonWriter fastjson.Writer
 	if err := metricsContainer.MarshalFastJSON(&jsonWriter); err != nil {
-		return apmproxy.APMData{}, err
+		return nil, err
 	}
 
-	return apmproxy.APMData{
-		Data: jsonWriter.Bytes(),
-	}, nil
+	return jsonWriter.Bytes(), nil
 }

--- a/logsapi/metrics_test.go
+++ b/logsapi/metrics_test.go
@@ -19,11 +19,9 @@ package logsapi
 
 import (
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
-	"github.com/elastic/apm-aws-lambda/apmproxy"
 	"github.com/elastic/apm-aws-lambda/extension"
 
 	"github.com/stretchr/testify/assert"
@@ -68,16 +66,10 @@ func TestProcessPlatformReport_Coldstart(t *testing.T) {
 
 	desiredOutputMetrics := fmt.Sprintf(`{"metricset":{"samples":{"faas.coldstart_duration":{"value":422.9700012207031},"faas.timeout":{"value":5000},"system.memory.total":{"value":1.34217728e+08},"system.memory.actual.free":{"value":5.4525952e+07},"faas.duration":{"value":182.42999267578125},"faas.billed_duration":{"value":183}},"timestamp":%d,"faas":{"coldstart":true,"execution":"6f7f0961f83442118a7af6fe80b88d56","id":"arn:aws:lambda:us-east-2:123456789012:function:custom-runtime"}}}`, timestamp.UnixNano()/1e3)
 
-	apmData, err := ProcessPlatformReport(&event, logEvent)
+	data, err := ProcessPlatformReport(&event, logEvent)
 	require.NoError(t, err)
 
-	requestBytes, err := apmproxy.GetUncompressedBytes(apmData.Data, "")
-	require.NoError(t, err)
-
-	out := string(requestBytes)
-	log.Println(out)
-
-	assert.JSONEq(t, desiredOutputMetrics, string(requestBytes))
+	assert.JSONEq(t, desiredOutputMetrics, string(data))
 }
 
 func TestProcessPlatformReport_NoColdstart(t *testing.T) {
@@ -118,13 +110,10 @@ func TestProcessPlatformReport_NoColdstart(t *testing.T) {
 
 	desiredOutputMetrics := fmt.Sprintf(`{"metricset":{"samples":{"faas.coldstart_duration":{"value":0},"faas.timeout":{"value":5000},"system.memory.total":{"value":1.34217728e+08},"system.memory.actual.free":{"value":5.4525952e+07},"faas.duration":{"value":182.42999267578125},"faas.billed_duration":{"value":183}},"timestamp":%d,"faas":{"coldstart":false,"execution":"6f7f0961f83442118a7af6fe80b88d56","id":"arn:aws:lambda:us-east-2:123456789012:function:custom-runtime"}}}`, timestamp.UnixNano()/1e3)
 
-	apmData, err := ProcessPlatformReport(&event, logEvent)
+	data, err := ProcessPlatformReport(&event, logEvent)
 	require.NoError(t, err)
 
-	requestBytes, err := apmproxy.GetUncompressedBytes(apmData.Data, "")
-	require.NoError(t, err)
-
-	assert.JSONEq(t, desiredOutputMetrics, string(requestBytes))
+	assert.JSONEq(t, desiredOutputMetrics, string(data))
 }
 
 func BenchmarkPlatformReport(b *testing.B) {


### PR DESCRIPTION
Currently, the package `apmproxy` is required by the package `logsapi` due to the abuse of `APMData` struct. The PR refactors the struct so that it's usage is contained within `apmproxy`.

Part of #315 