### PR TITLE
Prepare v1.2.0

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,15 +20,18 @@
 [[lambda-unreleased]]
 === Unreleased
 
-https://github.com/elastic/apm-aws-lambda/compare/v1.1.0...main[View commits]
-
+https://github.com/elastic/apm-aws-lambda/compare/v1.2.0...main[View commits]
 
 [float]
-===== Breaking changes
+[[lambda-1.2.0]]
+=== 1.2.0 - 2022/11/01
 
 [float]
 ===== Features
+- Parse and log APM Server error responses, and backoff on critical errors {lambda-pull}281[281]
 - Disable CGO to prevent libc/ABI compatibility issues {lambda-pull}292[292]
+- Deprecate `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS` in favour of `ELASTIC_APM_DATA_RECEIVER_TIMEOUT` {lambda-pull}294[294]
+- Log shutdown reason on exit {lambda-pull}297[297]
 - Add support for collecting and shipping function logs to APM Server {lambda-pull}303[303]
 - Batch data collected from lambda logs API before sending to APM Server {lambda-pull}314[314]
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,10 +4,9 @@
 ### Preparing a Release
 
 1. Update the [`CHANGELOG.asciidoc`](CHANGELOG.asciidoc), by adding a new version heading (`==== 1.x.x - yyyy/MM/dd`) and changing the base tag of the Unreleased comparison URL
-2. For major and minor releases, update the EOL table.
-3. Ensure all changes are merged into github.com/elastic/apm-aws-lambda@main
-4. Create a test plan for any changes that require manual testing. At the very minimum, a manual smoke test must be conducted before releasing. 
-5. Trigger a release after succesful testing.
+2. Ensure all changes are merged into github.com/elastic/apm-aws-lambda@main
+3. Create a test plan for any changes that require manual testing. At the very minimum, a manual smoke test must be conducted before releasing. 
+4. Trigger a release after succesful testing.
 
 ### Trigger a Release
 

--- a/extension/version.go
+++ b/extension/version.go
@@ -18,5 +18,5 @@
 package extension
 
 const (
-	Version = "1.1.0"
+	Version = "1.2.0"
 )


### PR DESCRIPTION
- Update version
- Update changelog, add missing entries
- Remove step about updating EOL from RELEASE.md, as EOL info is now centralised