### PR TITLE
Handle txn registration if invocation registration is late

### DIFF
--- a/accumulator/batch.go
+++ b/accumulator/batch.go
@@ -40,11 +40,10 @@ var (
 )
 
 var (
-	maxSizeThreshold     = 0.9
-	zeroTime             = time.Time{}
-	newLineSep           = []byte("\n")
-	transactionKey       = []byte("transaction")
-	waitingInvocationKey = "waiting"
+	maxSizeThreshold = 0.9
+	zeroTime         = time.Time{}
+	newLineSep       = []byte("\n")
+	transactionKey   = []byte("transaction")
 )
 
 // Batch manages the data that needs to be shipped to APM Server. It holds
@@ -92,20 +91,16 @@ func (b *Batch) RegisterInvocation(
 ) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	inc := &Invocation{
-		RequestID:   reqID,
-		FunctionARN: functionARN,
-		DeadlineMs:  deadlineMs,
-		Timestamp:   timestamp,
+
+	i, ok := b.invocations[reqID]
+	if !ok {
+		i = &Invocation{}
+		b.invocations[reqID] = i
 	}
-	if w, ok := b.invocations[waitingInvocationKey]; ok {
-		// If the agent payload is cached before the invocation is registered
-		// then associate the agent payload with the invocation.
-		inc.AgentPayload = w.AgentPayload
-		inc.TransactionID = w.TransactionID
-		delete(b.invocations, waitingInvocationKey)
-	}
-	b.invocations[reqID] = inc
+	i.RequestID = reqID
+	i.FunctionARN = functionARN
+	i.DeadlineMs = deadlineMs
+	i.Timestamp = timestamp
 	b.currentlyExecutingRequestID = reqID
 }
 

--- a/accumulator/batch_test.go
+++ b/accumulator/batch_test.go
@@ -180,7 +180,7 @@ func TestLifecycle(t *testing.T) {
 			b.RegisterInvocation(reqID, fnARN, ts.Add(txnDur).UnixMilli(), ts)
 			// Agent creates and registers a partial transaction in the extn
 			if tc.agentInit {
-				require.NoError(t, b.OnAgentInit(txnID, []byte(txnData)))
+				require.NoError(t, b.OnAgentInit(reqID, txnID, []byte(txnData)))
 			}
 			// Agent sends a request with metadata
 			require.NoError(t, b.AddAgentData(APMData{

--- a/accumulator/invocation.go
+++ b/accumulator/invocation.go
@@ -66,15 +66,24 @@ func (inc *Invocation) Finalize(status string, time time.Time) ([]byte, error) {
 	return inc.createProxyTxn(status, time)
 }
 
-func (inc *Invocation) createProxyTxn(status string, time time.Time) (txn []byte, err error) {
-	txn, err = sjson.SetBytes(inc.AgentPayload, "transaction.result", status)
+func (inc *Invocation) createProxyTxn(status string, time time.Time) ([]byte, error) {
+	txn, err := sjson.SetBytes(inc.AgentPayload, "transaction.result", status)
+	if err != nil {
+		return nil, err
+	}
 	// Transaction duration cannot be known in partial transaction payload. Estimate
 	// the duration based on the time provided. Time can be based on the runtimeDone
 	// log record or function deadline.
 	duration := time.Sub(inc.Timestamp)
 	txn, err = sjson.SetBytes(txn, "transaction.duration", duration.Milliseconds())
+	if err != nil {
+		return nil, err
+	}
 	if status != "success" {
 		txn, err = sjson.SetBytes(txn, "transaction.outcome", "failure")
+		if err != nil {
+			return nil, err
+		}
 	}
-	return
+	return txn, nil
 }

--- a/apmproxy/apmserver_test.go
+++ b/apmproxy/apmserver_test.go
@@ -702,7 +702,7 @@ func BenchmarkFlushAPMData(b *testing.B) {
 		for j := 0; j < 99; j++ {
 			apmClient.LambdaDataChannel <- []byte(`{"log":{"message":this is test log"}}`)
 		}
-		apmClient.FlushAPMData(context.Background(), false)
+		apmClient.FlushAPMData(context.Background())
 	}
 }
 

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -170,6 +170,11 @@ func (c *Client) handleTransactionRegistration() func(w http.ResponseWriter, r *
 			w.WriteHeader(http.StatusUnsupportedMediaType)
 			return
 		}
+		reqID := r.Header.Get("x-elastic-aws-request-id")
+		if reqID == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		rawBytes, err := io.ReadAll(r.Body)
 		defer r.Body.Close()
 		if err != nil {
@@ -183,7 +188,7 @@ func (c *Client) handleTransactionRegistration() func(w http.ResponseWriter, r *
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			return
 		}
-		if err := c.batch.OnAgentInit(txnID, rawBytes); err != nil {
+		if err := c.batch.OnAgentInit(reqID, txnID, rawBytes); err != nil {
 			c.logger.Warnf("Failed to update invocation for transaction ID %s: %v", txnID, err)
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			return

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -184,7 +184,7 @@ func (c *Client) handleTransactionRegistration() func(w http.ResponseWriter, r *
 			return
 		}
 		if err := c.batch.OnAgentInit(txnID, rawBytes); err != nil {
-			c.logger.Warnf("Failed to update invocation for transaction ID %s", txnID)
+			c.logger.Warnf("Failed to update invocation for transaction ID %s: %v", txnID, err)
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			return
 		}

--- a/app/run.go
+++ b/app/run.go
@@ -76,7 +76,7 @@ func (app *App) Run(ctx context.Context) error {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		app.apmClient.FlushAPMData(ctx, true)
+		app.apmClient.FlushAPMData(ctx)
 	}()
 
 	// The previous event id is used to validate the received Lambda metrics
@@ -109,7 +109,7 @@ func (app *App) Run(ctx context.Context) error {
 				// waiting for grace period if it got to unhealthy state.
 				flushCtx, cancel := context.WithCancel(ctx)
 				// Flush APM data now that the function invocation has completed
-				app.apmClient.FlushAPMData(flushCtx, false)
+				app.apmClient.FlushAPMData(flushCtx)
 				cancel()
 			}
 			prevEvent = event
@@ -131,7 +131,7 @@ func (app *App) processEvent(
 
 	// call Next method of extension API.  This long polling HTTP method
 	// will block until there's an invocation of the function
-	app.logger.Infof("Waiting for next event...")
+	app.logger.Info("Waiting for next event...")
 	event, err := app.extensionClient.NextEvent(ctx)
 	if err != nil {
 		app.logger.Errorf("Error: %s", err)
@@ -142,21 +142,35 @@ func (app *App) processEvent(
 		}
 
 		app.logger.Infof("Exit signal sent to runtime : %s", status)
-		app.logger.Infof("Exiting")
+		app.logger.Info("Exiting")
 		return nil, err
 	}
-	app.batch.RegisterInvocation(
-		event.RequestID,
-		event.InvokedFunctionArn,
-		event.DeadlineMs,
-		event.Timestamp,
-	)
+
 	// Used to compute Lambda Timeout
 	event.Timestamp = time.Now()
 	app.logger.Debug("Received event.")
 	app.logger.Debugf("%v", extension.PrettyPrint(event))
 
-	if event.EventType == extension.Shutdown {
+	switch event.EventType {
+	case extension.Invoke:
+		app.batch.RegisterInvocation(
+			event.RequestID,
+			event.InvokedFunctionArn,
+			event.DeadlineMs,
+			event.Timestamp,
+		)
+	case extension.Shutdown:
+		// At shutdown we can not expect platform.runtimeDone events to be reported
+		// for the remaining invocations. If we haven't received the transaction
+		// from agents at this point then it is safe to assume that the function
+		// timed out. We will create proxy transaction for all invocations that
+		// haven't received a full transaction from the agent yet. If extension
+		// doesn't have enough CPU time it is possible that the extension might
+		// not receive the shutdown signal for timeouts or runtime crashes. In
+		// these cases we will miss the transaction.
+		if err := app.batch.OnShutdown("timeout"); err != nil {
+			app.logger.Errorf("Error finalizing invocation on shutdown: %v", err)
+		}
 		return event, nil
 	}
 
@@ -193,7 +207,7 @@ func (app *App) processEvent(
 	}
 
 	// Calculate how long to wait for a runtimeDoneSignal or AgentDoneSignal signal
-	flushDeadlineMs := event.DeadlineMs - 100
+	flushDeadlineMs := event.DeadlineMs - 200
 	durationUntilFlushDeadline := time.Until(time.Unix(flushDeadlineMs/1000, 0))
 
 	// Create a timer that expires after durationUntilFlushDeadline
@@ -204,12 +218,12 @@ func (app *App) processEvent(
 	// the lambda function and the end of the execution of processEvent()
 	// 1) AgentDoneSignal is triggered upon reception of a `flushed=true` query from the agent
 	// 2) [Backup 1] RuntimeDone is triggered upon reception of a Lambda log entry certifying the end of the execution of the current function
-	// 3) [Backup 2] If all else fails, the extension relies of the timeout of the Lambda function to interrupt itself 100 ms before the specified deadline.
+	// 3) [Backup 2] If all else fails, the extension relies of the timeout of the Lambda function to interrupt itself 200 ms before the specified deadline.
 	// This time interval is large enough to attempt a last flush attempt (if SendStrategy == syncFlush) before the environment gets shut down.
 
 	select {
 	case <-app.apmClient.WaitForFlush():
-		app.logger.Debug("APM client has pending flush signals")
+		app.logger.Debug("APM client has sent flush signal")
 	case <-runtimeDone:
 		app.logger.Debug("Received runtimeDone signal")
 	case <-timer.C:

--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -47,7 +47,7 @@ const (
 type ClientOption func(*Client)
 
 type invocationLifecycler interface {
-	OnLambdaLogRuntimeDone(requestID, status string) error
+	OnLambdaLogRuntimeDone(requestID, status string, time time.Time) error
 }
 
 // Client is the client used to subscribe to the Logs API.

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -75,8 +75,12 @@ func (lc *Client) ProcessLogs(
 			case PlatformStart:
 				platformStartReqID = logEvent.Record.RequestID
 			case PlatformRuntimeDone:
-				if err := lc.invocationLifecycler.OnLambdaLogRuntimeDone(logEvent.Record.RequestID, logEvent.Record.Status); err != nil {
-					lc.logger.Warnf("Failed to finalize invocation with request ID %s", logEvent.Record.RequestID)
+				if err := lc.invocationLifecycler.OnLambdaLogRuntimeDone(
+					logEvent.Record.RequestID,
+					logEvent.Record.Status,
+					logEvent.Time,
+				); err != nil {
+					lc.logger.Warnf("Failed to finalize invocation with request ID %s: %v", logEvent.Record.RequestID, err)
 				}
 				// For the current invocation the platform.runtimeDone would be the last event
 				if logEvent.Record.RequestID == requestID {


### PR DESCRIPTION
## What the PR does?

- Transaction registration can happen before the invocation is registered. Handle such cases by keeping the payload of transaction registration in a cache and handling it when the invocation is registered.
- Transaction registration will not have the duration of the transaction or if it does have it, the value will be a default value. We attempt to calculate the transaction duration based on the invocation timestamp, function deadline(for timeouts), OR `runtimeDone` log timestamp for agent issues.
- Increases the timeout for the deadline of extension from 100ms to 200ms.

Related to https://github.com/elastic/apm-agent-go/issues/1323