### PR TITLE
Expose more options for the benchmarking tf module

### DIFF
--- a/testing/Makefile
+++ b/testing/Makefile
@@ -7,6 +7,7 @@ LOAD_ARRIVAL_RATE?=50
 LAMBDA_RUNTIME?=python3.8
 LAMBDA_TIMEOUT?=15
 LAMBDA_MEMORY_SIZE?=128
+CUSTOM_LAMBDA_EXTENSION_ARN?=
 LAMBDA_RUNTIME_NORM=$(subst '.','_',$(LAMBDA_RUNTIME))
 
 # TODO: @lahsivjar Add automation for terraform fmt and docs
@@ -44,4 +45,5 @@ terraform-init:
 		-var 'lambda_runtime=$(LAMBDA_RUNTIME)' \
 		-var 'lambda_timeout=$(LAMBDA_TIMEOUT)' \
 		-var 'lambda_memory_size=$(LAMBDA_MEMORY_SIZE)' \
-		-var 'stack_version=$(STACK_VERSION)'
+		-var 'stack_version=$(STACK_VERSION)' \
+		-var 'custom_lambda_extension_arn=$(CUSTOM_LAMBDA_EXTENSION_ARN)'

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -1,10 +1,12 @@
 USER_NAME?=$(USER)
 AWS_REGION?=us-west-2
 MACHINE_TYPE?=t2.medium
+STACK_VERSION?=latest
 LOAD_DURATION?=10
 LOAD_ARRIVAL_RATE?=50
 LAMBDA_RUNTIME?=python3.8
 LAMBDA_TIMEOUT?=15
+LAMBDA_MEMORY_SIZE?=128
 LAMBDA_RUNTIME_NORM=$(subst '.','_',$(LAMBDA_RUNTIME))
 
 # TODO: @lahsivjar Add automation for terraform fmt and docs
@@ -40,4 +42,6 @@ terraform-init:
 		-var 'load_duration=$(LOAD_DURATION)' \
 		-var 'load_arrival_rate=$(LOAD_ARRIVAL_RATE)' \
 		-var 'lambda_runtime=$(LAMBDA_RUNTIME)' \
-		-var 'lambda_timeout=$(LAMBDA_TIMEOUT)'
+		-var 'lambda_timeout=$(LAMBDA_TIMEOUT)' \
+		-var 'lambda_memory_size=$(LAMBDA_MEMORY_SIZE)' \
+		-var 'stack_version=$(STACK_VERSION)'

--- a/testing/benchmarking/README.md
+++ b/testing/benchmarking/README.md
@@ -1,0 +1,49 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.8, < 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+| <a name="requirement_ec"></a> [ec](#requirement\_ec) | >=0.4.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >=3.1.1 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_artillery_deployment"></a> [artillery\_deployment](#module\_artillery\_deployment) | ../tf-modules/artillery_deployment | n/a |
+| <a name="module_ec_deployment"></a> [ec\_deployment](#module\_ec\_deployment) | github.com/elastic/apm-server/testing/infra/terraform/modules/ec_deployment | n/a |
+| <a name="module_lambda_deployment"></a> [lambda\_deployment](#module\_lambda\_deployment) | ../tf-modules/lambda_deployment | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region to deploy lambda function | `string` | `"us-west-2"` | no |
+| <a name="input_custom_lambda_extension_arn"></a> [custom\_lambda\_extension\_arn](#input\_custom\_lambda\_extension\_arn) | Specific lambda extension to use, will use the latest build if not specified | `string` | `""` | no |
+| <a name="input_deployment_template"></a> [deployment\_template](#input\_deployment\_template) | Optional deployment template. Defaults to the CPU optimized template for GCP | `string` | `"gcp-compute-optimized-v2"` | no |
+| <a name="input_elasticsearch_size"></a> [elasticsearch\_size](#input\_elasticsearch\_size) | Optional Elasticsearch instance size | `string` | `"8g"` | no |
+| <a name="input_elasticsearch_zone_count"></a> [elasticsearch\_zone\_count](#input\_elasticsearch\_zone\_count) | Optional Elasticsearch zone count | `number` | `2` | no |
+| <a name="input_ess_region"></a> [ess\_region](#input\_ess\_region) | Optional ESS region where the deployment will be created. Defaults to gcp-us-west2 | `string` | `"gcp-us-west2"` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Amount of memory (in MB) the lambda function can use | `number` | `128` | no |
+| <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | The language-specific lambda runtime | `string` | `"python3.8"` | no |
+| <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout of the lambda function in seconds | `number` | `15` | no |
+| <a name="input_load_arrival_rate"></a> [load\_arrival\_rate](#input\_load\_arrival\_rate) | Rate(per second) at which the virtual users are generated | `number` | `50` | no |
+| <a name="input_load_duration"></a> [load\_duration](#input\_load\_duration) | Duration over which to generate new virtual users | `number` | `10` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type for artillery nodes | `string` | `"t2.medium"` | no |
+| <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to add to all created resource | `string` | n/a | yes |
+| <a name="input_stack_version"></a> [stack\_version](#input\_stack\_version) | Optional stack version | `string` | `"latest"` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/testing/benchmarking/main.tf
+++ b/testing/benchmarking/main.tf
@@ -59,6 +59,7 @@ module "lambda_deployment" {
   lambda_runtime     = var.lambda_runtime
   lambda_handler     = local.runtimeToHandler[var.lambda_runtime]
   lambda_invoke_path = local.load_req_path
+  lambda_memory_size = var.lambda_memory_size
 
   apm_server_url   = module.ec_deployment.apm_url
   apm_secret_token = module.ec_deployment.apm_secret_token

--- a/testing/benchmarking/main.tf
+++ b/testing/benchmarking/main.tf
@@ -56,10 +56,11 @@ module "lambda_deployment" {
   build_dir              = "../build"
   apm_aws_extension_path = "../../bin/extension.zip"
 
-  lambda_runtime     = var.lambda_runtime
-  lambda_handler     = local.runtimeToHandler[var.lambda_runtime]
-  lambda_invoke_path = local.load_req_path
-  lambda_memory_size = var.lambda_memory_size
+  lambda_runtime              = var.lambda_runtime
+  lambda_handler              = local.runtimeToHandler[var.lambda_runtime]
+  lambda_invoke_path          = local.load_req_path
+  lambda_memory_size          = var.lambda_memory_size
+  custom_lambda_extension_arn = var.custom_lambda_extension_arn
 
   apm_server_url   = module.ec_deployment.apm_url
   apm_secret_token = module.ec_deployment.apm_secret_token

--- a/testing/benchmarking/variables.tf
+++ b/testing/benchmarking/variables.tf
@@ -39,6 +39,12 @@ variable "lambda_timeout" {
   default     = 15
 }
 
+variable "lambda_memory_size" {
+  type        = number
+  description = "Amount of memory (in MB) the lambda function can use"
+  default     = 128
+}
+
 variable "ess_region" {
   type        = string
   description = "Optional ESS region where the deployment will be created. Defaults to gcp-us-west2"

--- a/testing/benchmarking/variables.tf
+++ b/testing/benchmarking/variables.tf
@@ -45,6 +45,12 @@ variable "lambda_memory_size" {
   default     = 128
 }
 
+variable "custom_lambda_extension_arn" {
+  type        = string
+  description = "Specific lambda extension to use, will use the latest build if not specified"
+  default     = ""
+}
+
 variable "ess_region" {
   type        = string
   description = "Optional ESS region where the deployment will be created. Defaults to gcp-us-west2"

--- a/testing/tf-modules/lambda_deployment/README.md
+++ b/testing/tf-modules/lambda_deployment/README.md
@@ -8,15 +8,13 @@ triggered with an no auth API gateway endpoint.
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.37.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
@@ -42,10 +40,11 @@ No modules.
 | <a name="input_apm_aws_extension_path"></a> [apm\_aws\_extension\_path](#input\_apm\_aws\_extension\_path) | Path to the zip file containing extension code | `string` | n/a | yes |
 | <a name="input_apm_secret_token"></a> [apm\_secret\_token](#input\_apm\_secret\_token) | Secret token for auth against the given server URL | `string` | n/a | yes |
 | <a name="input_apm_server_url"></a> [apm\_server\_url](#input\_apm\_server\_url) | APM Server URL for sending the generated load | `string` | n/a | yes |
-| <a name="input_aws_region"></a> [aws\_region](#input\_aws\_region) | AWS region to deploy lambda function | `string` | `"us-west-2"` | no |
 | <a name="input_build_dir"></a> [build\_dir](#input\_build\_dir) | Prefix to add to all created resource | `string` | n/a | yes |
+| <a name="input_custom_lambda_extension_arn"></a> [custom\_lambda\_extension\_arn](#input\_custom\_lambda\_extension\_arn) | Specific lambda extension to use, will use the latest build if not specified | `string` | `""` | no |
 | <a name="input_lambda_handler"></a> [lambda\_handler](#input\_lambda\_handler) | Entrypoint for the lambda function | `string` | `"main.handler"` | no |
 | <a name="input_lambda_invoke_path"></a> [lambda\_invoke\_path](#input\_lambda\_invoke\_path) | Request path to invoke the test lambda function | `string` | `"/test"` | no |
+| <a name="input_lambda_memory_size"></a> [lambda\_memory\_size](#input\_lambda\_memory\_size) | Amount of memory (in MB) the lambda function can use | `number` | `128` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | The language-specific lambda runtime | `string` | `"python3.8"` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Timeout of the lambda function in seconds | `number` | `15` | no |
 | <a name="input_resource_prefix"></a> [resource\_prefix](#input\_resource\_prefix) | Prefix to add to all created resource | `string` | n/a | yes |

--- a/testing/tf-modules/lambda_deployment/main.tf
+++ b/testing/tf-modules/lambda_deployment/main.tf
@@ -39,6 +39,7 @@ resource "aws_lambda_function" "test_fn" {
   source_code_hash = filebase64sha256(local.lambda_function_path)
   layers           = [aws_lambda_layer_version.extn_layer.arn]
   timeout          = var.lambda_timeout
+  memory_size      = var.lambda_memory_size
 
   environment {
     variables = {

--- a/testing/tf-modules/lambda_deployment/main.tf
+++ b/testing/tf-modules/lambda_deployment/main.tf
@@ -25,6 +25,7 @@ EOF
 }
 
 resource "aws_lambda_layer_version" "extn_layer" {
+  count      = var.custom_lambda_extension_arn == "" ? 1 : 0
   filename   = var.apm_aws_extension_path
   layer_name = "${var.resource_prefix}_apm_aws_lambda_extn"
 }
@@ -37,7 +38,7 @@ resource "aws_lambda_function" "test_fn" {
   handler          = var.lambda_handler
   runtime          = var.lambda_runtime
   source_code_hash = filebase64sha256(local.lambda_function_path)
-  layers           = [aws_lambda_layer_version.extn_layer.arn]
+  layers           = [var.custom_lambda_extension_arn == "" ? aws_lambda_layer_version.extn_layer[0].arn : var.custom_lambda_extension_arn]
   timeout          = var.lambda_timeout
   memory_size      = var.lambda_memory_size
 

--- a/testing/tf-modules/lambda_deployment/variables.tf
+++ b/testing/tf-modules/lambda_deployment/variables.tf
@@ -37,6 +37,12 @@ variable "lambda_invoke_path" {
   default     = "/test"
 }
 
+variable "lambda_memory_size" {
+  type        = number
+  description = "Amount of memory (in MB) the lambda function can use"
+  default     = 128
+}
+
 variable "apm_server_url" {
   type        = string
   description = "APM Server URL for sending the generated load"

--- a/testing/tf-modules/lambda_deployment/variables.tf
+++ b/testing/tf-modules/lambda_deployment/variables.tf
@@ -43,6 +43,12 @@ variable "lambda_memory_size" {
   default     = 128
 }
 
+variable "custom_lambda_extension_arn" {
+  type        = string
+  description = "Specific lambda extension to use, will use the latest build if not specified"
+  default     = ""
+}
+
 variable "apm_server_url" {
   type        = string
   description = "APM Server URL for sending the generated load"


### PR DESCRIPTION
The PR exposes stack version to `make` commands and adds support for setting lambda memory size as well as specifying custom lambda extension (by default we were building the current code and deploying it). With these changes we can test lambda functions with any version of the extension.