### PR TITLE
Enable cloudwatch logging for lambda deployment tf and other minor fixes

### DIFF
--- a/testing/benchmarking/main.tf
+++ b/testing/benchmarking/main.tf
@@ -17,7 +17,10 @@ terraform {
 }
 
 locals {
-  load_req_path = "/test"
+  load_req_path        = "/test"
+  name_from_runtime    = replace(var.lambda_runtime, ".", "_")
+  lambda_function_zip  = "../build/${local.name_from_runtime}.zip"
+  lambda_function_name = "${var.resource_prefix}_${local.name_from_runtime}_apm_aws_lambda"
   runtimeToHandler = {
     "python3.8" = "main.handler"
     "go1.x"     = "main"
@@ -53,10 +56,11 @@ module "lambda_deployment" {
 
   resource_prefix = var.resource_prefix
 
-  build_dir              = "../build"
   apm_aws_extension_path = "../../bin/extension.zip"
 
   lambda_runtime              = var.lambda_runtime
+  lambda_function_zip         = local.lambda_function_zip
+  lambda_function_name        = local.lambda_function_name
   lambda_handler              = local.runtimeToHandler[var.lambda_runtime]
   lambda_invoke_path          = local.load_req_path
   lambda_memory_size          = var.lambda_memory_size

--- a/testing/functions/python3.8/main.py
+++ b/testing/functions/python3.8/main.py
@@ -1,7 +1,7 @@
 import json
 from elasticapm import capture_serverless
 
-coldstart = True
+coldstart = "true"
 @capture_serverless()
 def handler(event, context):
     global coldstart
@@ -13,6 +13,6 @@ def handler(event, context):
             "coldstart": coldstart,
         }
     }
-    coldstart = False
+    coldstart = "false"
     return resp
 

--- a/testing/tf-modules/lambda_deployment/main.tf
+++ b/testing/tf-modules/lambda_deployment/main.tf
@@ -1,9 +1,3 @@
-locals {
-  name_from_runtime    = replace(var.lambda_runtime, ".", "_")
-  lambda_function_path = "${var.build_dir}/${local.name_from_runtime}.zip"
-  lambda_function_name = "${var.resource_prefix}_${local.name_from_runtime}_apm_aws_lambda"
-}
-
 resource "aws_iam_role" "iam_for_lambda" {
   name = "${var.resource_prefix}_apm_aws_lambda_iam"
 
@@ -32,12 +26,12 @@ resource "aws_lambda_layer_version" "extn_layer" {
 
 # TODO: @lahsivjar Add in cloudwatch integration for visualizing logs
 resource "aws_lambda_function" "test_fn" {
-  filename         = local.lambda_function_path
-  function_name    = local.lambda_function_name
+  filename         = var.lambda_function_zip
+  function_name    = var.lambda_function_name
   role             = aws_iam_role.iam_for_lambda.arn
   handler          = var.lambda_handler
   runtime          = var.lambda_runtime
-  source_code_hash = filebase64sha256(local.lambda_function_path)
+  source_code_hash = filebase64sha256(var.lambda_function_zip)
   layers           = [var.custom_lambda_extension_arn == "" ? aws_lambda_layer_version.extn_layer[0].arn : var.custom_lambda_extension_arn]
   timeout          = var.lambda_timeout
   memory_size      = var.lambda_memory_size
@@ -52,7 +46,7 @@ resource "aws_lambda_function" "test_fn" {
 }
 
 resource "aws_apigatewayv2_api" "trigger" {
-  name          = local.lambda_function_name
+  name          = var.lambda_function_name
   protocol_type = "HTTP"
   description   = "API Gateway to trigger lambda for testing apm-aws-lambda"
 }

--- a/testing/tf-modules/lambda_deployment/main.tf
+++ b/testing/tf-modules/lambda_deployment/main.tf
@@ -19,9 +19,10 @@ EOF
 }
 
 resource "aws_lambda_layer_version" "extn_layer" {
-  count      = var.custom_lambda_extension_arn == "" ? 1 : 0
-  filename   = var.apm_aws_extension_path
-  layer_name = "${var.resource_prefix}_apm_aws_lambda_extn"
+  count            = var.custom_lambda_extension_arn == "" ? 1 : 0
+  filename         = var.apm_aws_extension_path
+  layer_name       = "${var.resource_prefix}_apm_aws_lambda_extn"
+  source_code_hash = filebase64sha256(var.apm_aws_extension_path)
 }
 
 resource "aws_iam_role_policy_attachment" "cw" {

--- a/testing/tf-modules/lambda_deployment/variables.tf
+++ b/testing/tf-modules/lambda_deployment/variables.tf
@@ -3,14 +3,19 @@ variable "resource_prefix" {
   description = "Prefix to add to all created resource"
 }
 
-variable "build_dir" {
-  type        = string
-  description = "Prefix to add to all created resource"
-}
-
 variable "apm_aws_extension_path" {
   type        = string
   description = "Path to the zip file containing extension code"
+}
+
+variable "lambda_function_zip" {
+  type        = string
+  description = "Path to the zip package containing the lambda function to deploy"
+}
+
+variable "lambda_function_name" {
+  type        = string
+  description = "The name of the lambda function"
 }
 
 variable "lambda_runtime" {


### PR DESCRIPTION
- Adds support for cloudwatch logging for the lambda functions
- Fixes handling of bool variable in headers for the python lambda function
- Fixes the lambda extn layer handling to trigger an update on change of extension code
- Refactors the `lambda_deployment` module to have clear boundaries (should only handle deployment of a provided zip package)