### PR TITLE
test: disable cgo in go test function

### DIFF
--- a/testing/functions/go1.x/build.sh
+++ b/testing/functions/go1.x/build.sh
@@ -5,5 +5,5 @@
 
 set -e
 
-GOARCH=amd64 GOOS=linux go build main.go
+CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build main.go
 zip ../../build/go1_x.zip main


### PR DESCRIPTION
Disable cgo in go test function to ensure there are no glibc/ABI compatibility issues between the build host and the target Lambda execution environment.

Similar to https://github.com/elastic/apm-aws-lambda/pull/292

Discovered while testing https://github.com/elastic/apm-aws-lambda/pull/347
```
/var/task/main: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /var/task/main)
/var/task/main: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /var/task/main)
```