### PR TITLE
build: update notice to 2023

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Elasticsearch BV
+Copyright 2023 Elasticsearch BV
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
It's 2023 :tada: 

CI is failing because the year is not up to date.