### PR TITLE
Process platform report metrics when extn is lagging

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ https://github.com/elastic/apm-aws-lambda/compare/v1.2.0...main[View commits]
 ===== Features
 - experimental:[] Create proxy transaction with error results if not reported by agent {lambda-pull}315[315]
 - Wait for the final platform report metrics on shutdown {lambda-pull}347[347]
+- Process platform report metrics when extension is lagging {lambda-pull}358[358]
 
 [float]
 [[lambda-1.2.0]]

--- a/accumulator/batch.go
+++ b/accumulator/batch.go
@@ -82,6 +82,13 @@ func NewBatch(maxSize int, maxAge time.Duration) *Batch {
 	}
 }
 
+// Size returns the number of invocations cached in the batch.
+func (b *Batch) Size() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.invocations)
+}
+
 // RegisterInvocation registers a new function invocation against its request
 // ID. It also updates the caches for currently executing request ID.
 func (b *Batch) RegisterInvocation(

--- a/accumulator/batch.go
+++ b/accumulator/batch.go
@@ -185,6 +185,21 @@ func (b *Batch) OnLambdaLogRuntimeDone(reqID, status string, time time.Time) err
 	return b.finalizeInvocation(reqID, status, time)
 }
 
+// OnPlatformReport should be the last event for a request ID. On receiving the
+// platform.report event the batch will cleanup any datastructure for the request
+// ID. It will return some of the function metadata to allow the caller to enrich
+// the report metrics.
+func (b *Batch) OnPlatformReport(reqID string) (string, int64, time.Time, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	inc, ok := b.invocations[reqID]
+	if !ok {
+		return "", 0, time.Time{}, fmt.Errorf("invocation for requestID %s does not exist", reqID)
+	}
+	delete(b.invocations, reqID)
+	return inc.FunctionARN, inc.DeadlineMs, inc.Timestamp, nil
+}
+
 // OnShutdown flushes the data for shipping to APM Server by finalizing all
 // the invocation in the batch. If we haven't received a platform.runtimeDone
 // event for an invocation so far we won't be able to recieve it in time thus
@@ -201,6 +216,7 @@ func (b *Batch) OnShutdown(status string) error {
 		if err := b.finalizeInvocation(inc.RequestID, status, time); err != nil {
 			return err
 		}
+		delete(b.invocations, inc.RequestID)
 	}
 	return nil
 }
@@ -257,12 +273,16 @@ func (b *Batch) finalizeInvocation(reqID, status string, time time.Time) error {
 	if !ok {
 		return fmt.Errorf("invocation for requestID %s does not exist", reqID)
 	}
-	defer delete(b.invocations, reqID)
-	proxyTxn, err := inc.Finalize(status, time)
+	proxyTxn, err := inc.CreateProxyTxn(status, time)
 	if err != nil {
 		return err
 	}
-	return b.addData(proxyTxn)
+	err = b.addData(proxyTxn)
+	if err != nil {
+		return err
+	}
+	inc.Finalized = true
+	return nil
 }
 
 func (b *Batch) addData(data []byte) error {

--- a/accumulator/invocation_test.go
+++ b/accumulator/invocation_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFinalize(t *testing.T) {
+func TestCreateProxyTransaction(t *testing.T) {
 	txnDur := time.Second
 	for _, tc := range []struct {
 		name              string
@@ -89,7 +89,7 @@ func TestFinalize(t *testing.T) {
 				AgentPayload:        []byte(tc.payload),
 				TransactionObserved: tc.txnObserved,
 			}
-			result, err := inc.Finalize(tc.runtimeDoneStatus, ts.Add(txnDur))
+			result, err := inc.CreateProxyTxn(tc.runtimeDoneStatus, ts.Add(txnDur))
 			assert.Nil(t, err)
 			if len(tc.output) > 0 {
 				assert.JSONEq(t, tc.output, string(result))
@@ -114,7 +114,7 @@ func BenchmarkCreateProxyTxn(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := inc.createProxyTxn("success", txnDur)
+		_, err := inc.CreateProxyTxn("success", txnDur)
 		if err != nil {
 			b.Fail()
 		}

--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -48,6 +48,7 @@ type ClientOption func(*Client)
 
 type invocationLifecycler interface {
 	OnLambdaLogRuntimeDone(requestID, status string, time time.Time) error
+	OnPlatformReport(reqID string) (fnARN string, deadlineMs int64, ts time.Time, err error)
 }
 
 // Client is the client used to subscribe to the Logs API.

--- a/logsapi/client.go
+++ b/logsapi/client.go
@@ -49,6 +49,8 @@ type ClientOption func(*Client)
 type invocationLifecycler interface {
 	OnLambdaLogRuntimeDone(requestID, status string, time time.Time) error
 	OnPlatformReport(reqID string) (fnARN string, deadlineMs int64, ts time.Time, err error)
+	// Size should return the number of invocations waiting on platform.report
+	Size() int
 }
 
 // Client is the client used to subscribe to the Logs API.

--- a/logsapi/event.go
+++ b/logsapi/event.go
@@ -20,8 +20,6 @@ package logsapi
 import (
 	"context"
 	"time"
-
-	"github.com/elastic/apm-aws-lambda/extension"
 )
 
 // LogEventType represents the log type that is received in the log messages
@@ -63,7 +61,6 @@ func (lc *Client) ProcessLogs(
 	requestID string,
 	invokedFnArn string,
 	dataChan chan []byte,
-	prevEvent *extension.NextEventResponse,
 	isShutdown bool,
 ) {
 	// platformStartReqID is to identify the requestID for the function


### PR DESCRIPTION
The current extension will drop the `platform.report` logs if the platform report metrics are reported in an invocation that does not immediately succeed in the invocation generating the platform report. To prevent the logs from getting dropped the PR does the following changes:
1. Updates the lifecycle of the cached invocation data to be cleared on receiving `platform.report` metric for its corresponding request ID.
2. Query the cached invocation data instead of using the previous event and drop the log event if the prev event doesn't match the event's request ID.

Part of #334