### PR TITLE
[8.6] docs: update lambda config (#365)

### DIFF
--- a/docs/monitoring-aws-lambda.asciidoc
+++ b/docs/monitoring-aws-lambda.asciidoc
@@ -93,18 +93,10 @@ Instead of specifying the <<aws-lambda-config-authentication-keys>> as plain tex
 The configured name of your application or service.  The APM agent will use this value when reporting data to the APM Server. If unset, the APM agent will automatically set the value based on the Lambda function name. Use this config option if you want to group multiple Lambda functions under a single service entity in APM.
 
 [float]
-[[aws-lambda-config-data-receiver-timeout-seconds]]
-=== `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS`
-
-deprecated::[1.2.0,Replaced by `ELASTIC_APM_DATA_RECEIVER_TIMEOUT`. See <<aws-lambda-config-data-receiver-timeout>>]
-
-The {apm-lambda-ext}'s timeout value, in seconds, for receiving data from the APM agent. The _default_ is `15`.
-
-[float]
 [[aws-lambda-config-data-receiver-timeout]]
 === `ELASTIC_APM_DATA_RECEIVER_TIMEOUT`
 
-coming::[1.2.0,Replaces `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS`. See <<aws-lambda-config-data-receiver-timeout-seconds>>]
+[small]#Added in: v1.2.0. Replaces `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS`.#
 
 The {apm-lambda-ext}'s timeout value, for receiving data from the APM agent. The _default_ is `15s`.
 
@@ -113,18 +105,10 @@ The {apm-lambda-ext}'s timeout value, for receiving data from the APM agent. The
 The port on which the {apm-lambda-ext} listens to receive data from the APM agent. The _default_ is `8200`.
 
 [float]
-[[aws-lambda-config-data-forwarder-timeout-seconds]]
-=== `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS`
-
-deprecated::[1.2.0,Replaced by `ELASTIC_APM_DATA_FORWARDER_TIMEOUT`. See <<aws-lambda-config-data-forwarder-timeout>>]
-
-The timeout value, in seconds, for the {apm-lambda-ext}'s HTTP client sending data to the APM Server. The _default_ is `3`. If the extension's attempt to send APM data during this time interval is not successful, the extension queues back the data. Further attempts at sending the data are governed by an exponential backoff algorithm: data will be sent after a increasingly large grace period of 0, then circa 1, 4, 9, 16, 25 and 36 seconds, provided that the Lambda function execution is ongoing.
-
-[float]
 [[aws-lambda-config-data-forwarder-timeout]]
 === `ELASTIC_APM_DATA_FORWARDER_TIMEOUT`
 
-coming::[1.2.0,Replaces `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS`. See <<aws-lambda-config-data-forwarder-timeout-seconds>>]
+[small]#Added in: v1.2.0. Replaces `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS`.#
 
 The timeout value, for the {apm-lambda-ext}'s HTTP client sending data to the APM Server. The _default_ is `3s`. If the extension's attempt to send APM data during this time interval is not successful, the extension queues back the data. Further attempts at sending the data are governed by an exponential backoff algorithm: data will be sent after a increasingly large grace period of 0, then circa 1, 4, 9, 16, 25 and 36 seconds, provided that the Lambda function execution is ongoing.
 
@@ -147,6 +131,46 @@ though it ensures that all APM data is sent to the APM server.
 [float]
 === `ELASTIC_APM_LOG_LEVEL`
 The logging level to be used by both the APM Agent and the {apm-lambda-ext}. Supported values are `trace`, `debug`, `info`, `warning`, `error`, `critical` and `off`.
+
+[float]
+=== `ELASTIC_APM_LAMBDA_CAPTURE_LOGS`
+
+preview:[]
+Starting in Elastic Stack version 8.5.0, the Elastic APM lambda extension supports the collection of log events by default.
+Log events can be viewed in {kib} in the APM UI. Disable log collection by setting this to `false`.
+
+[NOTE]
+====
+You may see errors similar to the following in {stack} versions less than 8.5:
+
+[source,text]
+----
+client error: response status code: 400
+message: log: did not recognize object type
+----
+
+Users on older versions should disable log collection by setting `ELASTIC_APM_LAMBDA_CAPTURE_LOGS` to `false`.
+====
+
+[float]
+[[aws-lambda-config-deprecated]]
+=== Deprecated options
+
+[float]
+[[aws-lambda-config-data-receiver-timeout-seconds]]
+==== `ELASTIC_APM_DATA_RECEIVER_TIMEOUT_SECONDS`
+
+[small]#Deprecated in: v1.2.0. Use <<aws-lambda-config-data-receiver-timeout>> instead.#
+
+The {apm-lambda-ext}'s timeout value, in seconds, for receiving data from the APM agent. The _default_ is `15`.
+
+[float]
+[[aws-lambda-config-data-forwarder-timeout-seconds]]
+==== `ELASTIC_APM_DATA_FORWARDER_TIMEOUT_SECONDS`
+
+[small]#Deprecated in: v1.2.0. Use <<aws-lambda-config-data-forwarder-timeout>> instead.#
+
+The timeout value, in seconds, for the {apm-lambda-ext}'s HTTP client sending data to the APM Server. The _default_ is `3`. If the extension's attempt to send APM data during this time interval is not successful, the extension queues back the data. Further attempts at sending the data are governed by an exponential backoff algorithm: data will be sent after a increasingly large grace period of 0, then circa 1, 4, 9, 16, 25 and 36 seconds, provided that the Lambda function execution is ongoing.
 
 [[aws-lambda-secrets-manager]]
 == Using AWS Secrets Manager to manage APM authentication keys


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [docs: update lambda config (#365)](https://github.com/elastic/apm-aws-lambda/pull/365)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)