### PR TITLE
Fix release workflow

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,8 +79,6 @@ publishers:
     env:
       - AWS_ACCESS_KEY_ID={{ .Env.AWS_ACCESS_KEY_ID }}
       - AWS_SECRET_ACCESS_KEY={{ .Env.AWS_SECRET_ACCESS_KEY }}
-      - AWS_SECURITY_TOKEN={{ .Env.AWS_SECURITY_TOKEN }}
-      - AWS_SESSION_TOKEN={{ .Env.AWS_SESSION_TOKEN }}
       - ELASTIC_LAYER_NAME=elastic-apm-extension-ver-{{ replace (trimprefix .Tag "v") "." "-" }}
       - VERSION={{ .Tag }}
       - ARCHITECTURE={{ if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}


### PR DESCRIPTION
AWS_SESSION_TOKEN and AWS_SECURITY_TOKEN are only needed when using tools like aws-vault. But in the workflow we only have "standard" credentials.