### PR TITLE
Fix release workflow

### DIFF
--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 
 export AWS_FOLDER=${AWS_FOLDER:-.aws}
 export SUFFIX_ARN_FILE=${SUFFIX_ARN_FILE:-arn-file.md}
+
+# This needs to be set in GH actions
+# https://dotjoeblog.wordpress.com/2021/03/14/github-actions-aws-error-exit-code-255/
+# eu-west-1 is just a random region
 export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
 GOOS=${GOOS:?Please provide GOOS environment variable.}

--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 
 export AWS_FOLDER=${AWS_FOLDER:-.aws}
 export SUFFIX_ARN_FILE=${SUFFIX_ARN_FILE:-arn-file.md}
+export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
 
 GOOS=${GOOS:?Please provide GOOS environment variable.}
 GOARCH=${GOARCH:?Please provide GOARCH environment variable.}


### PR DESCRIPTION
## Details

The release workflow is failing with the error message

```
custom publisher: failed to publish artifacts: publishing: ./.ci/publish-aws.sh failed: exit status 255: 
<botocore.awsrequest.AWSRequest object at 0x7f34d9b59e20>
```

Source: https://github.com/elastic/apm-aws-lambda/actions/runs/4241148406/jobs/7371006495

The same issue is described in https://dotjoeblog.wordpress.com/2021/03/14/github-actions-aws-error-exit-code-255/

TL;DR

setting `AWS_DEFAULT_REGION` should fix the issue.

## Related Issues

- Closes https://github.com/elastic/observability-robots/issues/1593