### PR TITLE
Allow metadata in register transaction

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,6 +17,16 @@
 ////
 
 [float]
+[[lambda-unreleased]]
+=== Unreleased
+
+https://github.com/elastic/apm-aws-lambda/compare/v1.3.1...main[View commits]
+
+[float]
+===== Features
+- experimental:[] Allow metadata in register transaction {lambda-pull}384[384]
+
+[float]
 [[lambda-1.3.1]]
 === 1.3.1 - 2023/04/04
 


### PR DESCRIPTION
The PR updates the `/register/transaction` endpoint to accept `NDJSON`. The `/register/transaction` endpoint can now accept `metadata` as the first event in `NDJSON` body and cache it for future calls. A complete list of changes introduced in the PR is as follows:

1. Change the `Content-Type` for the `/register/transaction` endpoint from `application/vnd.elastic.apm.transaction+json` to `application/vnd.elastic.apm.transaction+ndjson`.
2. Add support for `deflate` and `gzip` content encoding for the `/register/transaction` endpoint.
3. Allow `metadata` as the first event in the `NDJSON` body to the `/register/transaction` endpoint. The `metadata` is cached and used to send data to APM-Server. The cached metadata is NOT updated by the metadata sent via the intake endpoint.

### Related Issue

Closes #352 