### PR TITLE
Rename CreateProxyTxn to MaybeCreateProxyTxn

### DIFF
--- a/accumulator/batch.go
+++ b/accumulator/batch.go
@@ -311,7 +311,7 @@ func (b *Batch) finalizeInvocation(reqID, status string, time time.Time) error {
 	if !ok {
 		return fmt.Errorf("invocation for requestID %s does not exist", reqID)
 	}
-	proxyTxn, err := inc.CreateProxyTxn(status, time)
+	proxyTxn, err := inc.MaybeCreateProxyTxn(status, time)
 	if err != nil {
 		return err
 	}

--- a/accumulator/invocation.go
+++ b/accumulator/invocation.go
@@ -57,11 +57,13 @@ func (inc *Invocation) NeedProxyTransaction() bool {
 	return !inc.Finalized && inc.TransactionID != "" && !inc.TransactionObserved
 }
 
-// CreateProxyTxn creates a proxy transaction for an invocation if required.
-// A proxy transaction will be required to be created if the agent has
-// registered a transaction for the invocation but has not sent the
-// corresponding transaction to the extension.
-func (inc *Invocation) CreateProxyTxn(status string, time time.Time) ([]byte, error) {
+// MaybeCreateProxyTxn creates a proxy transaction for an invocation
+// if required. A proxy transaction will be required to be created
+// if the agent has registered a transaction for the invocation but
+// has not sent the corresponding transaction to the extension. The
+// proxy transaction will not be created if the invocation has
+// already been finalized or the agent has reported the transaction.
+func (inc *Invocation) MaybeCreateProxyTxn(status string, time time.Time) ([]byte, error) {
 	if !inc.NeedProxyTransaction() {
 		return nil, nil
 	}

--- a/accumulator/invocation_test.go
+++ b/accumulator/invocation_test.go
@@ -89,7 +89,7 @@ func TestCreateProxyTransaction(t *testing.T) {
 				AgentPayload:        []byte(tc.payload),
 				TransactionObserved: tc.txnObserved,
 			}
-			result, err := inc.CreateProxyTxn(tc.runtimeDoneStatus, ts.Add(txnDur))
+			result, err := inc.MaybeCreateProxyTxn(tc.runtimeDoneStatus, ts.Add(txnDur))
 			assert.Nil(t, err)
 			if len(tc.output) > 0 {
 				assert.JSONEq(t, tc.output, string(result))
@@ -100,7 +100,7 @@ func TestCreateProxyTransaction(t *testing.T) {
 	}
 }
 
-func BenchmarkCreateProxyTxn(b *testing.B) {
+func BenchmarkMaybeCreateProxyTxn(b *testing.B) {
 	ts := time.Date(2022, time.October, 1, 1, 0, 0, 0, time.UTC)
 	txnDur := ts.Add(time.Second)
 	inc := &Invocation{
@@ -114,7 +114,7 @@ func BenchmarkCreateProxyTxn(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := inc.CreateProxyTxn("success", txnDur)
+		_, err := inc.MaybeCreateProxyTxn("failure", txnDur)
 		if err != nil {
 			b.Fail()
 		}


### PR DESCRIPTION
Renames `CreateProxyTxn` to `MaybeCreateProxyTxn` as it better represents what the function does. A proxy transaction will be created only if it is needed. A proxy transaction will be needed if:

1. A transaction with the same `transaction.id` as the one registered during agent init is not reported by the agent.
2. An invocation has already been finalized before.
3. Transaction hasn't been successfully registered during agent init.