### PR TITLE
Prepare for v1.4.0 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -17,10 +17,10 @@
 ////
 
 [float]
-[[lambda-unreleased]]
-=== Unreleased
+[[lambda-1.4.0]]
+=== 1.4.0 - 2023/05/03
 
-https://github.com/elastic/apm-aws-lambda/compare/v1.3.1...main[View commits]
+https://github.com/elastic/apm-aws-lambda/compare/v1.3.1...v1.4.0[View commits]
 
 [float]
 ===== Features

--- a/extension/version.go
+++ b/extension/version.go
@@ -18,5 +18,5 @@
 package extension
 
 const (
-	Version = "1.3.0"
+	Version = "1.4.0"
 )


### PR DESCRIPTION
Release lambda extension `v1.4.0` with updated register transaction method.