### PR TITLE
fix: send auth headers with info requests if missing

### DIFF
--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -107,6 +107,15 @@ func (c *Client) handleInfoRequest() (func(w http.ResponseWriter, r *http.Reques
 		r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
 		r.Host = parsedApmServerURL.Host
 
+		// Send authorization header if the APM agent did not already forwarded it
+		if r.Header.Get("Authorization") == "" {
+			if c.ServerAPIKey != "" {
+				r.Header.Add("Authorization", "ApiKey "+c.ServerAPIKey)
+			} else if c.ServerSecretToken != "" {
+				r.Header.Add("Authorization", "Bearer "+c.ServerSecretToken)
+			}
+		}
+
 		// Forward request to the APM server
 		reverseProxy.ServeHTTP(w, r)
 	}, nil

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -108,12 +108,10 @@ func (c *Client) handleInfoRequest() (func(w http.ResponseWriter, r *http.Reques
 		r.Host = parsedApmServerURL.Host
 
 		// Send authorization header if the APM agent did not already forwarded it
-		if r.Header.Get("Authorization") == "" {
-			if c.ServerAPIKey != "" {
-				r.Header.Add("Authorization", "ApiKey "+c.ServerAPIKey)
-			} else if c.ServerSecretToken != "" {
-				r.Header.Add("Authorization", "Bearer "+c.ServerSecretToken)
-			}
+		if c.ServerAPIKey != "" {
+			r.Header.Add("Authorization", "ApiKey "+c.ServerAPIKey)
+		} else if c.ServerSecretToken != "" {
+			r.Header.Add("Authorization", "Bearer "+c.ServerSecretToken)
 		}
 
 		// Forward request to the APM server

--- a/apmproxy/receiver.go
+++ b/apmproxy/receiver.go
@@ -107,7 +107,7 @@ func (c *Client) handleInfoRequest() (func(w http.ResponseWriter, r *http.Reques
 		r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
 		r.Host = parsedApmServerURL.Host
 
-		// Send authorization header if the APM agent did not already forwarded it
+		// Override authorization header sent by the APM agents
 		if c.ServerAPIKey != "" {
 			r.Header.Add("Authorization", "ApiKey "+c.ServerAPIKey)
 		} else if c.ServerSecretToken != "" {

--- a/apmproxy/receiver_test.go
+++ b/apmproxy/receiver_test.go
@@ -41,7 +41,7 @@ func TestInfoProxy(t *testing.T) {
 	// Create apm server and handler
 	apmServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for key := range headers {
-			assert.Equal(t, 1, len(r.Header[key]))
+			assert.Equal(t, 2, len(r.Header[key]))
 			assert.Equal(t, headers[key], r.Header[key][0])
 		}
 		w.Header().Add("test", "header")


### PR DESCRIPTION
Forward auth headers for info requests. This does not affect data ingestion as we are already forwarding the headers there.

A test has been added to ensure the auth options passed to the lambda extension are correctly forwarded.

Closes https://github.com/elastic/apm-aws-lambda/issues/389