### PR TITLE
test: use AWS Secrets manager in smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dist/
 .aws-*/
 *arn-file.md
 
+tf/*.zip


### PR DESCRIPTION
Slightly related to https://github.com/elastic/apm-aws-lambda/issues/389

Debugging and reproducing the issue was a pain. This PR improves the smoke test to use the AWS secret manager instead of passing the secret token directly.

This should have more coverage and make it easier for developer to reproduce issues with the secrets manager.

The third-party terraform-aws-modules provider has also been removed in favour of the "official" aws provider.