### PR TITLE
docs: use the 'latest' GH release API for the latest extension or agent release

### DIFF
--- a/docs/lambda-selector/lambda-attributes-selector.asciidoc
+++ b/docs/lambda-selector/lambda-attributes-selector.asciidoc
@@ -86,21 +86,12 @@ const addArnGenerator = async (type, ghRepo, arnPattern) => {
   var releaseArns = [];
 
   const retrieveLatestLayerVersion = async () => {
-    const releases = await fetch(`https://api.github.com/repos/elastic/${ghRepo}/releases`).then(data => {
+    var latestRelease = await fetch(`https://api.github.com/repos/elastic/${ghRepo}/releases/latest`).then(data => {
         return data.status >= 400 ? undefined : data.json();
       });
 
-    if(releases){
-      var latestRelease = releases[0];
-
-      releases.forEach(release => {
-        if(Date.parse(release.created_at) > Date.parse(latestRelease.created_at)){
-          latestRelease = release;
-        }
-      });
-
+    if (latestRelease) {
       releaseArns = latestRelease.body.match(layerArnPattern);
-
       version = latestRelease.tag_name.replace("v","ver-").replace(/\./g, '-');
     } else {
       document.getElementById("default-arn-selector-section").style.display = "none";


### PR DESCRIPTION
The "Monitoring AWS Lambda $lang Functions" doc pages use some
in-browser JS to interpolate the ARNs for the latest Lambda extension
release and the latest APM agent release. This changes that JS to use
the "latest release" GH API
    https://api.github.com/repos/elastic/${ghRepo}/releases/latest
rather than listing all (or the first page of GH releases):
    https://api.github.com/repos/elastic/${ghRepo}/releases
and picking the latest by `release.created_at`.

GH releases for a repo have a sense of the "latest" release
(see `--latest` flag to https://cli.github.com/manual/gh_release_create)
even if it isn't the latest tag or published release in time. The
Node.js APM agent will soon have 4.x releases and 3.x maintenance
releases. It is possible that a 3.x release is the latest in time, but
not marked as the "latest" release. This change ensures that the
Lambda doc page will pick the correct (4.x) one.

# Testing notes

I tested this with a local build of the Node.js APM agent docs.
I've confirmed that this `https://api.github.com/repos/elastic/${ghRepo}/releases/latest` API works with
the apm-aws-lambda, apm-agent-python, and apm-agent-java repos -- the only other ones for which this doc JS is run.
