### PR TITLE
[8.9] docs: use the 'latest' GH release API for the latest extension or agent release (#402)

### DIFF
--- a/docs/lambda-selector/lambda-attributes-selector.asciidoc
+++ b/docs/lambda-selector/lambda-attributes-selector.asciidoc
@@ -86,21 +86,12 @@ const addArnGenerator = async (type, ghRepo, arnPattern) => {
   var releaseArns = [];
 
   const retrieveLatestLayerVersion = async () => {
-    const releases = await fetch(`https://api.github.com/repos/elastic/${ghRepo}/releases`).then(data => {
+    var latestRelease = await fetch(`https://api.github.com/repos/elastic/${ghRepo}/releases/latest`).then(data => {
         return data.status >= 400 ? undefined : data.json();
       });
 
-    if(releases){
-      var latestRelease = releases[0];
-
-      releases.forEach(release => {
-        if(Date.parse(release.created_at) > Date.parse(latestRelease.created_at)){
-          latestRelease = release;
-        }
-      });
-
+    if (latestRelease) {
       releaseArns = latestRelease.body.match(layerArnPattern);
-
       version = latestRelease.tag_name.replace("v","ver-").replace(/\./g, '-');
     } else {
       document.getElementById("default-arn-selector-section").style.display = "none";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [docs: use the 'latest' GH release API for the latest extension or agent release (#402)](https://github.com/elastic/apm-aws-lambda/pull/402)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)