### PR TITLE
ci: force tearing down the infrastructure

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,6 +29,7 @@ jobs:
       TF_VAR_BRANCH: "${{ github.ref_name }}"
       TF_VAR_REPO: "${{ github.repository }}"
       SMOKETEST_VERSIONS: "${{ inputs.smoketest_versions || 'latest' }}"
+      SKIP_DESTROY: 0
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3

--- a/tf/cleanup.sh
+++ b/tf/cleanup.sh
@@ -6,4 +6,4 @@ export TF_IN_AUTOMATION=1
 export TF_CLI_ARGS=-no-color
 
 echo "-> Tearing down the underlying infrastructure..."
-terraform destroy -auto-approve | tee -a tf.log
+terraform destroy -auto-approve >> tf.log

--- a/tf/cleanup.sh
+++ b/tf/cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+export TF_IN_AUTOMATION=1
+export TF_CLI_ARGS=-no-color
+
+echo "-> Tearing down the underlying infrastructure..."
+terraform destroy -auto-approve | tee -a tf.log

--- a/tf/test.sh
+++ b/tf/test.sh
@@ -8,7 +8,7 @@ export TF_CLI_ARGS=-no-color
 cleanup() {
   if [ "$SKIP_DESTROY" != "1" ]; then
     echo "-> Tearing down the underlying infrastructure..."
-    terraform destroy -auto-approve | tee -a tf.log
+    terraform destroy -auto-approve >> tf.log
   fi
 }
 

--- a/tf/test.sh
+++ b/tf/test.sh
@@ -6,7 +6,10 @@ export TF_IN_AUTOMATION=1
 export TF_CLI_ARGS=-no-color
 
 cleanup() {
-  [ "$SKIP_DESTROY" != "1" ]; terraform destroy -auto-approve >> tf.log
+  if [ "$SKIP_DESTROY" != "1" ]; then
+    echo "-> Tearing down the underlying infrastructure..."
+    terraform destroy -auto-approve | tee -a tf.log
+  fi
 }
 
 trap "cleanup" EXIT


### PR DESCRIPTION
`cleanup.sh` didn't exist so it didn't get triggered automatically and the trap uses some env variable to skip the destroy