### PR TITLE
fix: upload two artifacts

### DIFF
--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
-          artifact: test-results            # artifact name
-          name: JUnit Tests                 # Name of the check run which will be created
+          artifact: /test-results-(.*)/
+          name: 'JUnit Tests $1'
           path: "*-junit-report.xml"        # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: test-results
+          name: test-results-${{ matrix.platform }}
           path: '*-junit-report.xml'
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recent changes in the upload artifacts action do not allow to update artifacts anymore so we have to upload two files with the tests results and process them separately.

see https://github.com/actions/toolkit/tree/main/packages/artifact#breaking-changes