### PR TITLE
fix: use the correct secret

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,7 +45,7 @@ jobs:
           secrets: |
             secret/observability-team/ci/elastic-observability-aws-account-auth access_key | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/elastic-observability-aws-account-auth secret_key | AWS_SECRET_ACCESS_KEY ;
-            secret/observability-team/ci/elastic-cloud/observability-pro apiKey | EC_API_KEY
+            secret/observability-team/ci/elastic-cloud/observability-team-pro apiKey | EC_API_KEY
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.2.3


### PR DESCRIPTION
The secrets was deprecated a few months ago and is no longer updated, and the key was deleted.