### PR TITLE
feat: add `ELASTIC_APM_LAMBDA_DISABLE_LOGS_API` env var to disable logs api

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,7 +47,8 @@ func main() {
 		app.WithAWSConfig(cfg),
 	}
 
-	if os.Getenv("ELASTIC_APM_LAMBDA_DISABLE_LOGS_API") == "true" {
+	rawDisableLogsAPI := os.Getenv("ELASTIC_APM_LAMBDA_DISABLE_LOGS_API")
+	if disableLogsAPI, _ := strconv.ParseBool(rawDisableLogsAPI); disableLogsAPI {
 		appConfigs = append(appConfigs, app.WithoutLogsAPI())
 	}
 


### PR DESCRIPTION
Add flag to disable Logs API dubscription: `ELASTIC_APM_LAMBDA_DISABLE_LOGS_API`

Mostly for debugging. It should be tested before being documented as it's currently logging a warning on each event.