### PR TITLE
test: use name_prefix to create unique aws resources

### DIFF
--- a/tf/.gitignore
+++ b/tf/.gitignore
@@ -1,5 +1,6 @@
 .terraform/
 
+.terraform.lock.hcl
 *.tfstate
 *.tfstate.*
 

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = "iam_for_lambda"
+  name_prefix        = "apm-aws-lambda-smoke-testing-iam-role"
   assume_role_policy = data.aws_iam_policy_document.assume_role.json
 }
 
@@ -50,7 +50,7 @@ data "archive_file" "lambda" {
 
 resource "aws_lambda_function" "test_lambda" {
   filename      = "lambda_function_payload.zip"
-  function_name = "smoke-testing-test"
+  function_name = "${var.user_name}-smoke-testing-test"
   role          = aws_iam_role.lambda.arn
   handler       = "index.handler"
 
@@ -74,7 +74,7 @@ resource "aws_lambda_function" "test_lambda" {
 }
 
 resource "aws_secretsmanager_secret" "apm_secret_token" {
-  name                    = "lambda-extension-smoke-testing-secret"
+  name_prefix             = "apm-aws-lambda-smoke-testing-secret"
   recovery_window_in_days = 0
 }
 
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "policy" {
 }
 
 resource "aws_iam_policy" "secrets_manager_elastic_apm_policy" {
-  name        = "secrets_manager_elastic_apm_policy"
+  name_prefix = "apm-aws-lambda-smoke-testing-iam-policy"
   description = "Allows the lambda function to access the APM secret token stored in AWS Secrets Manager."
   policy      = data.aws_iam_policy_document.policy.json
 }

--- a/tf/output.tf
+++ b/tf/output.tf
@@ -19,3 +19,7 @@ output "aws_region" {
   value       = var.aws_region
   description = "The AWS region"
 }
+
+output "user_name" {
+  value = var.user_name
+}

--- a/tf/test.sh
+++ b/tf/test.sh
@@ -25,10 +25,11 @@ if [[ -z "${GITHUB_WORKFLOW}" ]]; then
 fi
 
 AWS_REGION=$($TERRAFORM_WRAPPER output -raw aws_region)
+FUNCTION_NAME=$($TERRAFORM_WRAPPER output -raw user_name)-smoke-testing-test
 
 echo "-> Calling the lambda function..."
-aws lambda invoke --region="${AWS_REGION}" --function-name smoke-testing-test response.json
-aws lambda invoke --region="${AWS_REGION}" --function-name smoke-testing-test response.json
+aws lambda invoke --region="${AWS_REGION}" --function-name "${FUNCTION_NAME}" response.json
+aws lambda invoke --region="${AWS_REGION}" --function-name "${FUNCTION_NAME}" response.json
 
 echo "-> Waiting for the agent documents to be indexed in Elasticsearch..."
 


### PR DESCRIPTION
Use `name_prefix` instead of `name` to create unique aws resources and avoid smoke tests failing because resources already exist.

Upon investigation it looks like some resources were still around in AWS. I've deleted them manually and run the smoke test manually to confirm it works.

To reproduce: `EC_API_KEY=apikey TEST_DIR=tf make smoketest/run`