### PR TITLE
feat: add dependabot go dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,19 @@
 version: 2
 updates:
+  # go dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      aws:
+        patterns:
+        - "github.com/aws/*"
+  # go tools
+  - package-ecosystem: "gomod"
+    directory: "tools/"
+    schedule:
+      interval: "weekly"
 
   # GitHub actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Add go tools and go dependencies dependabot groups.

Dependabot is currently being used to bump github actions in this repo. This PR adds go.mod groups to keep go dependencies up to date.