### PR TITLE
Provenance docker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,35 @@ jobs:
         with:
           subject-path: "${{ github.workspace }}/dist/*.*"
 
+      # See https://github.com/github-early-access/generate-build-provenance/issues/162
+      - name: container image digest
+        id: image
+        run: |
+          set -euo pipefail
+          # Gather the container image generated with goreleaser
+          image=$(jq -r '.[] | select (.type=="Docker Image") | .path' dist/artifacts.json | cut -d':' -f1 | uniq)
+          image_1=$(echo $image | head -n1)
+          image_2=$(echo $image | tail -n1)
+          # Fetch the digest for the container image (amd64 and arm64)
+          digest_1=$(docker images --format "{{.Digest}}" --no-trunc $image | sed -n 1p)
+          digest_2=$(docker images --format "{{.Digest}}" --no-trunc $image | sed -n 2p)
+          echo "name_1=$image" >> "$GITHUB_OUTPUT"
+          echo "name_2=$image" >> "$GITHUB_OUTPUT"
+          echo "digest_1=$digest_1" >> "$GITHUB_OUTPUT"
+          echo "digest_2=$digest_2" >> "$GITHUB_OUTPUT"
+
+      - name: generate build provenance (containers x86_64)
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: ${{ steps.image.outputs.name_1 }}
+          subject-digest: ${{ steps.image.outputs.digest_1 }}
+
+      - name: generate build provenance (containers arm64)
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-name: ${{ steps.image.outputs.name_2 }}
+          subject-digest: ${{ steps.image.outputs.digest_2 }}
+
       - name: GitHub Release
         run: make release-notes
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,14 @@ jobs:
       - name: Release
         run: make release
 
+      # Store artifacts to help with troubleshooting
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: release
+          path: "dist/*.*"
+          retention-days: 5
+
       - name: generate build provenance (binaries)
         uses: github-early-access/generate-build-provenance@main
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -72,6 +72,12 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.version={{ .Version }}"
 
+docker_manifests:
+- name_template: '{{ .Env.DOCKER_REGISTRY }}/{{ .Env.DOCKER_IMAGE_NAME }}:{{ trimprefix .Tag "v" }}'
+  image_templates:
+  - '{{ .Env.DOCKER_REGISTRY }}/{{ .Env.DOCKER_IMAGE_NAME }}-x86_64:{{ trimprefix .Tag "v" }}'
+  - '{{ .Env.DOCKER_REGISTRY }}/{{ .Env.DOCKER_IMAGE_NAME }}-arm64:{{ trimprefix .Tag "v" }}'
+
 publishers:
   - name: publish-aws
     cmd: ./.ci/publish-aws.sh


### PR DESCRIPTION
### What

Use https://github.com/github-early-access/generate-build-provenance/tree/main/?tab=readme-ov-file#container-image for the container images.

Support to multi-arch docker images with `goreleaser`.

Then we can figure out if `dist/artifacts.json` contains the multi-arch entry, when using `goreleaser --snapshot` I cannot find that particular entry.

### Issues

Partially implemented for binaries in https://github.com/elastic/apm-aws-lambda/pull/448
https://github.com/github-early-access/generate-build-provenance/issues/162 could potentially reduce the number of github-actions calls for the docker containers.
