### PR TITLE
github-action: update dependabot PRs with NOTICE.txt

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,0 +1,41 @@
+---
+# Dependabot Pull Requests are not updating the NOTICE.txt file, which causes the lint job to fail.
+# This workflow will checkout the dependabot PR, update the NOTICE.txt file, and push the changes back to the PR.
+name: update-dependabot-pr
+
+on:
+  push:
+    branches:
+      - dependabot/go_modules/**
+    paths-ignore:
+      - NOTICE.txt
+
+permissions:
+  contents: read
+
+jobs:
+  update-dependabot-pr:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Update NOTICE.txt
+        run: make NOTICE.txt
+        # inspired by https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c
+      - name: Commit changes (signed)
+        run: |
+          export BRANCH=${GITHUB_REF#refs/heads/}
+          export SHA=$(git rev-parse "$BRANCH:$FILE_TO_COMMIT")
+          gh api --method PUT "/repos/${REPO}/contents/$FILE_TO_COMMIT" \
+            --field message="Update $FILE_TO_COMMIT" \
+            --field content=@<(base64 -i $FILE_TO_COMMIT) \
+            --field sha="${SHA}" \
+            --field branch="${BRANCH}"
+        env:
+          FILE_TO_COMMIT: NOTICE.txt
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Similar to https://github.com/elastic/apm-server/blob/main/.github/workflows/update-dependabot-pr.yml

Dependabot bumps in the apm-aws-lambda are failing because the notice file is not updated along with the dependency version.
example: https://github.com/elastic/apm-aws-lambda/pull/457