### PR TITLE
github-action: use composite action and fix smoke-tests

### DIFF
--- a/.github/actions/bootstrap/action.yml
+++ b/.github/actions/bootstrap/action.yml
@@ -1,0 +1,31 @@
+---
+name: Bootstrap Checkout
+description: Ensures all actions bootstrap the same
+
+inputs:
+  goreleaser:
+    description: 'Install goreleaser toolchain ("true" or "false")'
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - uses: docker/setup-qemu-action@v3
+      if: "${{ inputs.goreleaser == 'true' }}"
+      with:
+        platforms: linux/arm64, linux/amd64
+
+    - name: Set up Docker Buildx
+      if: "${{ inputs.goreleaser == 'true' }}"
+      uses: docker/setup-buildx-action@v3
+
+    # See https://goreleaser.com/blog/supply-chain-security/
+    - name: installs syft for generating the SBOM with goreleaser
+      if: "${{ inputs.goreleaser == 'true' }}"
+      uses: anchore/sbom-action/download-syft@v0.15.10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,17 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  # GitHub composite actions
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/bootstrap"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    reviewers:
+      - "elastic/observablt-ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
+
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
+
       - name: Update NOTICE.txt
         run: make NOTICE.txt
         # inspired by https://gist.github.com/swinton/03e84635b45c78353b1f71e41007fc7c

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          check-latest: true
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64, linux/amd64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:
           registry: docker.elastic.co
@@ -48,9 +39,10 @@ jobs:
             secret/observability-team/ci/service-account/apm-aws-lambda access_key_id | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/service-account/apm-aws-lambda secret_access_key | AWS_SECRET_ACCESS_KEY
 
-      # See https://goreleaser.com/blog/supply-chain-security/
-      - name: installs syft for generating the SBOM with goreleaser
-        uses: anchore/sbom-action/download-syft@v0.15.10
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
+        with:
+          goreleaser: 'true'
 
       - name: Release
         run: make release

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,9 +32,6 @@ jobs:
       SKIP_DESTROY: 0
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
       - name: Import Secrets
         uses: hashicorp/vault-action@v3.0.0
         with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -32,6 +32,10 @@ jobs:
       SKIP_DESTROY: 0
     steps:
       - uses: actions/checkout@v4
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
+        with:
+          goreleaser: 'true'
       - name: Import Secrets
         uses: hashicorp/vault-action@v3.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,9 +34,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
       - name: Test
         run: make test junitfile="${{ matrix.platform }}-junit-report.xml"
       - uses: actions/upload-artifact@v3
@@ -51,17 +50,11 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
         with:
-          go-version-file: 'go.mod'
-      - uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/arm64, linux/amd64
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      # See https://goreleaser.com/blog/supply-chain-security/
-      - name: installs syft for generating the SBOM with goreleaser
-        uses: anchore/sbom-action/download-syft@v0.15.10
+          goreleaser: 'true'
 
       - name: Build
         run: make dist
@@ -82,9 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
+      - name: Bootstrap Action Workspace
+        uses: ./.github/actions/bootstrap
       - run: make lint-prep
       - run: make lint
       - run: go vet


### PR DESCRIPTION
Fixes a regression when enabled the `goreleaser` with sbom. The smoke-tests uses `goreleaser` and I didn't detect it in https://github.com/elastic/apm-aws-lambda/blob/62236d32ae7613a4f82fefff471b09e4b1e1aca0/Makefile#L72

I refactored the code to use a composite action to reuse the same steps in the different GitHub workflows