### PR TITLE
Allow running release job with workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v*.*.*


### PR DESCRIPTION
So we can rerun the release workflow against the proper tag, and fix the issue in #462.