### PR TITLE
github-action: avoid release if github release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Validate tag does not exist on current commit
+        run: |
+          if [ $(git tag -l "${{ github.ref_name }}") ]; then
+            echo "The tag ${{ github.ref_name  }} already exists"
+            exit 1
+          fi
+
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:
           registry: docker.elastic.co

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate tag does not exist on current commit
+      - name: Validate GitHub release is not available yet
         run: |
-          if [ $(git tag -l "${{ github.ref_name }}") ]; then
-            echo "The tag ${{ github.ref_name  }} already exists"
+          if gh release view "${{ github.ref_name }} > /dev/null ; then
+            echo "The GitHub release ${{ github.ref_name  }} already exists"
             exit 1
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
         with:


### PR DESCRIPTION
### What

If a github release exists, then it fails. Avoid rerunning the workflow since AWS lambdas are immutable and their versions are bumped if created a new one.


### Why
This should avoid the [edge case](https://github.com/elastic/apm-aws-lambda/issues/462) that a GitHub workflow was triggered accidentally and remove the lambdas.

### Test

<img width="895" alt="image" src="https://github.com/elastic/apm-aws-lambda/assets/2871786/10ef86ba-8f35-48b1-95df-048a48927311">


### Further details

> github.ref_name	string	The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.
For pull requests, the format is <pr_number>/merge.