### PR TITLE
ci: use secrets from the source of truth

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,6 +33,9 @@ jobs:
       # TODO: replace with keyless (likely AWS)
       AWS_ACCESS_KEY_ID: ${{ secrets.OBSERVABILITY_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.OBSERVABILITY_AWS_SECRET_ACCESS_KEY }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap Action Workspace

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,10 +30,9 @@ jobs:
       TF_VAR_REPO: "${{ github.repository }}"
       SMOKETEST_VERSIONS: "${{ inputs.smoketest_versions || 'latest' }}"
       SKIP_DESTROY: 0
-      # TODO: replace with keyless (likely AWS and Google Secrets Manager)
+      # TODO: replace with keyless (likely AWS)
       AWS_ACCESS_KEY_ID: ${{ secrets.OBSERVABILITY_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.OBSERVABILITY_AWS_SECRET_ACCESS_KEY }}
-      EC_API_KEY: ${{ secrets.OBSERVABILITY_EC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - name: Bootstrap Action Workspace
@@ -43,6 +42,13 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.2.3
+
+      - uses: google-github-actions/get-secretmanager-secrets@dc4a1392bad0fd60aee00bb2097e30ef07a1caae # v2.1.3
+        with:
+          export_to_environment: true
+          secrets: |-
+            EC_API_KEY:elastic-observability/secrets/elastic-cloud-observability-team-pro-api-key
+
       - run: make smoketest/run TEST_DIR=./tf
       - if: always()
         name: Tear down

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -46,11 +46,13 @@ jobs:
         with:
           terraform_version: 1.2.3
 
+      - uses: elastic/oblt-actions/google/auth@v1
+
       - uses: google-github-actions/get-secretmanager-secrets@dc4a1392bad0fd60aee00bb2097e30ef07a1caae # v2.1.3
         with:
           export_to_environment: true
           secrets: |-
-            EC_API_KEY:elastic-observability/secrets/elastic-cloud-observability-team-pro-api-key
+            EC_API_KEY:elastic-observability/elastic-cloud-observability-team-pro-api-key
 
       - run: make smoketest/run TEST_DIR=./tf
       - if: always()

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           terraform_version: 1.2.3
       - uses: elastic/oblt-actions/aws/auth@v1
+      - uses: elastic/oblt-actions/google/auth@v1
       - uses: google-github-actions/get-secretmanager-secrets@dc4a1392bad0fd60aee00bb2097e30ef07a1caae # v2.1.3
         with:
           export_to_environment: true


### PR DESCRIPTION
`oblt-cli` is not using vault anymore. Let's use the correct secret storage


### Test

Running the smoke-tests using a test feature branch:
- https://github.com/elastic/apm-aws-lambda/actions/runs/9658938892/job/26641201571

