### PR TITLE
Use keyless authentication for smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -47,8 +47,8 @@ jobs:
         name: Tear down
         run: make smoketest/all/cleanup TEST_DIR=./tf
 
-      - if: always()
-        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
-        with:
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: "#apm-aws-lambda"
+#      - if: always()
+#        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
+#        with:
+#          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+#          channel-id: "#apm-aws-lambda"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -30,9 +30,6 @@ jobs:
       TF_VAR_REPO: "${{ github.repository }}"
       SMOKETEST_VERSIONS: "${{ inputs.smoketest_versions || 'latest' }}"
       SKIP_DESTROY: 0
-      # TODO: replace with keyless (likely AWS and Google Secrets Manager)
-      AWS_ACCESS_KEY_ID: ${{ secrets.OBSERVABILITY_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.OBSERVABILITY_AWS_SECRET_ACCESS_KEY }}
       EC_API_KEY: ${{ secrets.OBSERVABILITY_EC_API_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -43,6 +40,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.2.3
+      - uses: elastic/oblt-actions/aws/auth@v1.10.0
       - run: make smoketest/run TEST_DIR=./tf
       - if: always()
         name: Tear down

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -14,6 +14,7 @@ concurrency: ${{ github.workflow }}
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -47,8 +47,8 @@ jobs:
         name: Tear down
         run: make smoketest/all/cleanup TEST_DIR=./tf
 
-#      - if: always()
-#        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
-#        with:
-#          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-#          channel-id: "#apm-aws-lambda"
+      - if: always()
+        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-aws-lambda"

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -108,7 +108,7 @@ locals {
 
 resource "aws_lambda_layer_version" "lambda_layer" {
   filename   = "../dist/${local.zip_files[0]}"
-  layer_name = "lambda_layer_name"
+  layer_name = "apm-aws-lambda-smoke-testing-lambda_layer_name"
 
   description         = "AWS Lambda Extension Layer for Elastic APM - smoke testing"
   compatible_runtimes = ["nodejs16.x"]


### PR DESCRIPTION
- use the observability-ci AWS account instead of elastic-observability
- use [elastic/oblt-actions/aws/auth@v1.10.0](https://github.com/elastic/oblt-actions/tree/v1.10.0/aws/auth) for authenticating keyless with OIDC to the default CI AWS account. 


tested in https://github.com/elastic/apm-aws-lambda/actions/runs/9646343492
