### PR TITLE
test: automatically use GitHub username

### DIFF
--- a/testing/smoketest/get_username.sh
+++ b/testing/smoketest/get_username.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -eu
+
+# The gh command is faster and not as hacky as the fallback solution
+if which gh >/dev/null; then
+  user_name=$(gh api user -q ".login")
+else
+  user_name=$(ssh -T git@github.com 2>&1|cut -d'!' -f1|cut -d' ' -f2)
+fi
+
+echo "{\"user_name\": \"${user_name}\"}"

--- a/testing/smoketest/locals.tf
+++ b/testing/smoketest/locals.tf
@@ -1,0 +1,7 @@
+data "external" "username" {
+  program = ["./get_username.sh"]
+}
+
+locals {
+  user_name = data.external.username.result.user_name
+}

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -7,7 +7,7 @@ provider "aws" {
 
 module "tags" {
   source  = "github.com/elastic/apm-server//testing/infra/terraform/modules/tags?depth=1"
-  project = var.user_name
+  project = local.user_name
 }
 
 module "ec_deployment" {
@@ -74,7 +74,7 @@ data "archive_file" "lambda" {
 
 resource "aws_lambda_function" "test_lambda" {
   filename      = "lambda_function_payload.zip"
-  function_name = "${var.user_name}-smoke-testing-test"
+  function_name = "${local.user_name}-smoke-testing-test"
   role          = aws_iam_role.lambda.arn
   handler       = local.runtimeVars[var.function_runtime]["handler"]
 
@@ -103,7 +103,7 @@ resource "aws_lambda_function" "test_lambda" {
 }
 
 resource "aws_cloudwatch_log_group" "example" {
-  name              = "/aws/lambda/${var.user_name}-smoke-testing-test"
+  name              = "/aws/lambda/${local.user_name}-smoke-testing-test"
   retention_in_days = 1
 }
 

--- a/testing/smoketest/output.tf
+++ b/testing/smoketest/output.tf
@@ -21,7 +21,7 @@ output "aws_region" {
 }
 
 output "user_name" {
-  value = var.user_name
+  value = local.user_name
 }
 
 output "agent_name" {

--- a/testing/smoketest/variables.tf
+++ b/testing/smoketest/variables.tf
@@ -4,11 +4,6 @@ variable "aws_region" {
   default     = "eu-central-1"
 }
 
-variable "user_name" {
-  description = "Required username to use for prefixes"
-  type        = string
-}
-
 variable "function_runtime" {
   description = "function runtime and apm agent "
   type        = string


### PR DESCRIPTION
The smoketest so far required manual input of the username, used as a tag for the AWS lambda environment.
This changes the smoketest to automatically use the GitHub username. The name is retrieved by either using the `gh` tool or, as a fallback, using `ssh`.