### PR TITLE
ci: Add obs-ds-ebpf-go team

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,7 +27,7 @@ jobs:
       id: checkUserMember
       with:
         username: ${{ github.actor }}
-        team: 'apm'
+        team: 'apm,obs-ds-ebpf-go'
         usernamesToExclude: |
           apmmachine
           dependabot


### PR DESCRIPTION
The Elastic obs-ds-ebpf-go team is currently responsible for maintaining the repository. Adding the team to the labeler avoids creating 'community' and 'triage' labels for issues and PRs created by members.