### PR TITLE
ci: Check observability instead of apm team for issue/PR authors

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,7 +27,7 @@ jobs:
       id: checkUserMember
       with:
         username: ${{ github.actor }}
-        team: 'apm'
+        team: 'observability'
         usernamesToExclude: |
           apmmachine
           dependabot


### PR DESCRIPTION
Automatically setting 'community' and 'triage' labels for issues and PRs now is disabled for members of the observability team.