### PR TITLE
test: Use automatically created GITHUB_TOKEN for smoketest

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ github.token }}
       SSH_KEY: "./id_rsa_terraform"
       TF_VAR_private_key: "./id_rsa_terraform"
       TF_VAR_public_key: "./id_rsa_terraform.pub"

--- a/testing/smoketest/get_username.sh
+++ b/testing/smoketest/get_username.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -eu
 
+: ${CI:=""}
+
+if [ -z "$CI" ]; then
+  user_name="github-actions"
 # The gh command is faster and not as hacky as the fallback solution
-if which gh >/dev/null; then
+elif which gh >/dev/null; then
   user_name=$(gh api user -q ".login")
 else
   user_name=$(ssh -T git@github.com 2>&1|cut -d'!' -f1|cut -d' ' -f2)


### PR DESCRIPTION
This hopefully fixes the error from `gh` in the smoketest:
```
Program: ./get_username.sh
Error Message: gh: Resource not accessible by integration (HTTP 403)
```
