### PR TITLE
fix: use unique name to avoid issues when running in the CI

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,3 +53,9 @@ jobs:
       - if: always()
         name: Tear down
         run: make smoketest/cleanup
+
+      - if: always()
+        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
+        with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-aws-lambda"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -53,9 +53,3 @@ jobs:
       - if: always()
         name: Tear down
         run: make smoketest/cleanup
-
-      - if: always()
-        uses: elastic/oblt-actions/slack/notify-result@v1.9.3
-        with:
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: "#apm-aws-lambda"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -23,8 +23,7 @@ jobs:
       SSH_KEY: "./id_rsa_terraform"
       TF_VAR_private_key: "./id_rsa_terraform"
       TF_VAR_public_key: "./id_rsa_terraform.pub"
-      TF_VAR_user_name: "apm-aws-lambda-${{ github.run_id }}"
-
+      TF_VAR_github_workflow_id: "apm-aws-lambda-${{ github.run_id }}-${{ github.run_number }}"
       TF_VAR_BUILD_ID: "${{ github.run_id }}"
       TF_VAR_ENVIRONMENT: 'ci'
       TF_VAR_BRANCH: "${{ github.ref_name }}"

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "lambda_logging" {
 }
 
 resource "aws_iam_policy" "lambda_logging" {
-  name        = "${local.user_name}-smoketest_extension_lambda_logging-${var.github_workflow_id}"
+  name        = "${local.user_name}-smoke-testing-test-${var.github_workflow_id}"
   path        = "/"
   description = "IAM policy for logging during smoketest for apm aws lambda extension"
   policy      = data.aws_iam_policy_document.lambda_logging.json

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -103,7 +103,7 @@ resource "aws_lambda_function" "test_lambda" {
 }
 
 resource "aws_cloudwatch_log_group" "example" {
-  name              = "/aws/lambda/${local.user_name}-smoke-testing-test"
+  name              = "/aws/lambda/${local.user_name}-smoke-testing-test-${var.github_workflow_id}"
   retention_in_days = 1
 }
 

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -122,7 +122,7 @@ data "aws_iam_policy_document" "lambda_logging" {
 }
 
 resource "aws_iam_policy" "lambda_logging" {
-  name        = "smoketest_extension_lambda_logging"
+  name        = "${local.user_name}-smoketest_extension_lambda_logging-${var.github_workflow_id}"
   path        = "/"
   description = "IAM policy for logging during smoketest for apm aws lambda extension"
   policy      = data.aws_iam_policy_document.lambda_logging.json

--- a/testing/smoketest/variables.tf
+++ b/testing/smoketest/variables.tf
@@ -33,3 +33,9 @@ variable "ess_version" {
   description = "ess version"
   default     = "8.[0-9]?([0-9]).[0-9]?([0-9])$"
 }
+
+variable "github_workflow_id" {
+  type        = string
+  description = "The GitHub Workflow ID"
+  default     = "1"
+}


### PR DESCRIPTION
tear-down does not cleanup the `aws_cloudwatch_log_group`, I'd assume is because the retention policy is honoured.

Therefore, it's required to use an unique name, otherwise it will fail with:


```
Error: creating CloudWatch Logs Log Group (/aws/lambda/github-actions-smoke-testing-test): operation error CloudWatch Logs: CreateLogGroup, https response error StatusCode: 400, RequestID: 4161b73e-8b5b-4fef-8a17-64aa29c2cdd4, ResourceAlreadyExistsException: The specified log group already exists

  with aws_cloudwatch_log_group.example,
  on main.tf line 105, in resource "aws_cloudwatch_log_group" "example":
 105: resource "aws_cloudwatch_log_group" "example" {


Error: creating IAM Policy (smoketest_extension_lambda_logging): operation error IAM: CreatePolicy, https response error StatusCode: 409, RequestID: 7560b89b-1e26-4c58-a6c1-1ca0e5eeca30, EntityAlreadyExists: A policy called smoketest_extension_lambda_logging already exists. Duplicate names are not allowed.

  with aws_iam_policy.lambda_logging,
  on main.tf line 124, in resource "aws_iam_policy" "lambda_logging":
 124: resource "aws_iam_policy" "lambda_logging" {
```

It creates a new resource:

<img width="705" alt="image" src="https://github.com/user-attachments/assets/2e2b5b35-bd2d-4533-8fb9-f474c5760b88">


closes https://github.com/elastic/apm-aws-lambda/issues/526