### PR TITLE
terraform: configure github workflow run id

### DIFF
--- a/testing/benchmarking/main.tf
+++ b/testing/benchmarking/main.tf
@@ -49,6 +49,7 @@ provider "aws" {
 module "tags" {
   source  = "github.com/elastic/apm-server//testing/infra/terraform/modules/tags?depth=1"
   project = "lambda-extension-benchmarks"
+  build   = vars.github_workflow_id
 }
 
 module "ec_deployment" {

--- a/testing/benchmarking/variables.tf
+++ b/testing/benchmarking/variables.tf
@@ -85,3 +85,9 @@ variable "elasticsearch_zone_count" {
   description = "Optional Elasticsearch zone count"
   default     = 2
 }
+
+variable "github_workflow_id" {
+  type        = string
+  description = "The GitHub Workflow ID"
+  default     = "1"
+}

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -8,6 +8,7 @@ provider "aws" {
 module "tags" {
   source  = "github.com/elastic/apm-server//testing/infra/terraform/modules/tags?depth=1"
   project = local.user_name
+  build   = vars.github_workflow_id
 }
 
 module "ec_deployment" {


### PR DESCRIPTION
Honours the changes in https://github.com/elastic/apm-server/pull/13841

I could not find how the `testing/benchmarking` gets triggered, but I applied some changes to include the new var.