### PR TITLE
tf: use singular var

### DIFF
--- a/testing/benchmarking/main.tf
+++ b/testing/benchmarking/main.tf
@@ -49,7 +49,7 @@ provider "aws" {
 module "tags" {
   source  = "github.com/elastic/apm-server//testing/infra/terraform/modules/tags?depth=1"
   project = "lambda-extension-benchmarks"
-  build   = vars.github_workflow_id
+  build   = var.github_workflow_id
 }
 
 module "ec_deployment" {

--- a/testing/smoketest/main.tf
+++ b/testing/smoketest/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 module "tags" {
   source  = "github.com/elastic/apm-server//testing/infra/terraform/modules/tags?depth=1"
   project = local.user_name
-  build   = vars.github_workflow_id
+  build   = var.github_workflow_id
 }
 
 module "ec_deployment" {


### PR DESCRIPTION
I accidentally used `vars` but it's not a valid name but `var` instead 👼 

https://github.com/elastic/apm-aws-lambda/actions/runs/10316386121 should validate this PR