### PR TITLE
Avoid race conditions when handling data

### DIFF
--- a/accumulator/batch.go
+++ b/accumulator/batch.go
@@ -37,6 +37,8 @@ var (
 	// ErrInvalidEncoding is returned for any APMData that is encoded
 	// with any encoding format
 	ErrInvalidEncoding = errors.New("encoded data not supported")
+	// ErrNoData indicates that APMData.data is empty
+	ErrNoData = errors.New("no data")
 )
 
 var (
@@ -170,7 +172,7 @@ func (b *Batch) OnAgentInit(reqID, contentEncoding string, raw []byte) error {
 // before adding any events then ErrBatchFull is returned.
 func (b *Batch) AddAgentData(apmData APMData) error {
 	if len(apmData.Data) == 0 {
-		return nil
+		return ErrNoData
 	}
 	raw, err := GetUncompressedBytes(apmData.Data, apmData.ContentEncoding)
 	if err != nil {

--- a/accumulator/batch_test.go
+++ b/accumulator/batch_test.go
@@ -48,6 +48,10 @@ func TestAdd(t *testing.T) {
 
 		assert.ErrorIs(t, ErrBatchFull, b.AddLambdaData([]byte(`{"log":{}}`)))
 	})
+	t.Run("empty AddAgentData", func(t *testing.T) {
+		b := NewBatch(1, time.Hour)
+		assert.ErrorIs(t, ErrNoData, b.AddAgentData(APMData{}))
+	})
 }
 
 func TestReset(t *testing.T) {

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -60,6 +60,10 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 			return nil
 		case data := <-c.AgentDataChannel:
 			if err := c.forwardAgentData(ctx, data); err != nil {
+				if errors.Is(err, accumulator.ErrNoData) {
+					c.logger.Debug("received something from AgentDataChannel without APMData")
+					continue
+				}
 				return err
 			}
 			// Wait for metadata to be available, metadata will be available as soon as

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -61,11 +61,11 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 			c.logger.Debug("Invocation context cancelled, not processing any more agent data")
 			return nil
 		case data := <-c.AgentDataChannel:
+			if len(data.Data) == 0 {
+				c.logger.Debugf("Received something from '%s' without APMData", data.AgentInfo)
+				continue
+			}
 			if err := c.forwardAgentData(ctx, data); err != nil {
-				if errors.Is(err, accumulator.ErrNoData) {
-					c.logger.Debugf("Received something from '%s' without APMData", data.AgentInfo)
-					continue
-				}
 				return err
 			}
 			once.Do(func() {

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -63,7 +63,7 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 		case data := <-c.AgentDataChannel:
 			if err := c.forwardAgentData(ctx, data); err != nil {
 				if errors.Is(err, accumulator.ErrNoData) {
-					c.logger.Debug("received something from AgentDataChannel without APMData")
+					c.logger.Debugf("received something from '%s' without APMData", data.AgentInfo)
 					continue
 				}
 				return err

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -28,8 +28,8 @@ import (
 	"math"
 	"math/rand"
 	"net/http"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/elastic/apm-aws-lambda/accumulator"
 	"github.com/elastic/apm-aws-lambda/version"

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -63,7 +63,7 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 		case data := <-c.AgentDataChannel:
 			if err := c.forwardAgentData(ctx, data); err != nil {
 				if errors.Is(err, accumulator.ErrNoData) {
-					c.logger.Debugf("received something from '%s' without APMData", data.AgentInfo)
+					c.logger.Debugf("Received something from '%s' without APMData", data.AgentInfo)
 					continue
 				}
 				return err

--- a/apmproxy/apmserver.go
+++ b/apmproxy/apmserver.go
@@ -69,8 +69,8 @@ func (c *Client) ForwardApmData(ctx context.Context) error {
 				return err
 			}
 			once.Do(func() {
-				// Wait for metadata to be available, metadata will be available as soon as
-				// the first agent data is processed.
+				// With the first successful request to c.forwardAgent Data() metadata should be
+				// available and processing data from c.LambdaDataChannel can start.
 				lambdaDataChan = c.LambdaDataChannel
 			})
 		case data := <-lambdaDataChan:


### PR DESCRIPTION
Initialize local variable only once and make sure expected APMData is handled first.