### PR TITLE
Upgrade go to 1.23 and golangci-lint to 1.64

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     #   - too many non-sensical warnings
     #   - not relevant for us
     #   - false positives
-    # 
+    #
     # "might be worth fixing" means we should investigate/fix in the mid term
     - canonicalheader
     - contextcheck # might be worth fixing
@@ -54,7 +54,6 @@ linters:
     - godot
     - godox # complains about TODO etc
     - gofumpt
-    - gomnd
     - gomoddirectives
     - inamedparam
     - interfacebloat
@@ -77,8 +76,6 @@ linters:
     - wastedassign
     - wsl
     - wrapcheck
-    # the following linters are deprecated
-    - execinquery
     # we don't want to change code to Go 1.22+ yet
     - intrange
     - copyloopvar

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL = /bin/bash -eo pipefail
 
 GORELEASER_VERSION = "v1.19.2"
 GO_LICENSER_VERSION = "v0.4.0"
-GOLANGCI_LINT_VERSION = "v1.59.1"
+GOLANGCI_LINT_VERSION = "v1.64.4"
 export DOCKER_IMAGE_NAME = observability/apm-lambda-extension
 export DOCKER_REGISTRY = docker.elastic.co
 

--- a/e2e-testing/e2e_test.go
+++ b/e2e-testing/e2e_test.go
@@ -39,10 +39,12 @@ import (
 	"go.uber.org/zap"
 )
 
-var rebuildPtr = flag.Bool("rebuild", false, "rebuild lambda functions")
-var langPtr = flag.String("lang", "nodejs", "the language of the Lambda test function : Java, Node, or Python")
-var timerPtr = flag.Int("timer", 20, "the timeout of the test lambda function")
-var javaAgentVerPtr = flag.String("java-agent-ver", "1.28.4", "the version of the java APM agent")
+var (
+	rebuildPtr      = flag.Bool("rebuild", false, "rebuild lambda functions")
+	langPtr         = flag.String("lang", "nodejs", "the language of the Lambda test function : Java, Node, or Python")
+	timerPtr        = flag.Int("timer", 20, "the timeout of the test lambda function")
+	javaAgentVerPtr = flag.String("java-agent-ver", "1.28.4", "the version of the java APM agent")
+)
 
 func TestEndToEnd(t *testing.T) {
 	// Check the only mandatory environment variable
@@ -103,7 +105,7 @@ func TestEndToEnd(t *testing.T) {
 		t.Fail()
 	}
 	l.Infof("Querying the mock server for transaction bound to %s...", samServiceName)
-	assert.True(t, strings.Contains(mockAPMServerLog, testUUID))
+	assert.Contains(t, mockAPMServerLog, testUUID)
 }
 
 func runTestWithTimer(l *zap.SugaredLogger, path, serviceName, serverURL string, buildFlag bool, lambdaFuncTimeout int, resultsChan chan string) string {
@@ -134,10 +136,12 @@ func runTest(l *zap.SugaredLogger, path, serviceName, serverURL string, buildFla
 	uuidWithHyphen := uuid.New().String()
 	urlSlice := strings.Split(serverURL, ":")
 	port := urlSlice[len(urlSlice)-1]
-	RunCommandInDir(l, "sam", []string{"local", "invoke", "--parameter-overrides",
+	RunCommandInDir(l, "sam", []string{
+		"local", "invoke", "--parameter-overrides",
 		"ParameterKey=ApmServerURL,ParameterValue=http://host.docker.internal:" + port,
 		"ParameterKey=TestUUID,ParameterValue=" + uuidWithHyphen,
-		"ParameterKey=TimeoutParam,ParameterValue=" + strconv.Itoa(lambdaFuncTimeout)},
+		"ParameterKey=TimeoutParam,ParameterValue=" + strconv.Itoa(lambdaFuncTimeout),
+	},
 		path)
 	l.Infof("%s execution complete", serviceName)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/apm-aws-lambda
 
-go 1.22
+go 1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.1

--- a/logsapi/model/model_json.go
+++ b/logsapi/model/model_json.go
@@ -82,7 +82,7 @@ func (v *FAAS) MarshalFastJSON(w *fastjson.Writer) error {
 	return nil
 }
 
-func (v *MetricsContainer) MarshalFastJSON(w *fastjson.Writer) error {
+func (v MetricsContainer) MarshalFastJSON(w *fastjson.Writer) error {
 	var firstErr error
 	w.RawByte('{')
 	if v.Metrics != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -439,7 +438,7 @@ func startLogSender(ctx context.Context, q <-chan logsapi.LogEvent, logsapiAddr 
 			return err
 		}
 		defer resp.Body.Close()
-		if resp.StatusCode/100 != 2 { //nolint:usestdlibvars
+		if resp.StatusCode/100 != 2 {
 			return fmt.Errorf("received a non 2xx status code: %d", resp.StatusCode)
 		}
 		return nil
@@ -569,8 +568,7 @@ func TestLateFlush(t *testing.T) {
 	case <-runApp(t, logsapiAddr):
 		assert.Regexp(
 			t,
-			regexp.MustCompile(fmt.Sprintf(".*\n%s.*\n%s", TimelyResponse,
-				TimelyResponse)), // metadata followed by TimelyResponsex2
+			fmt.Sprintf(".*\n%s.*\n%s", TimelyResponse, TimelyResponse), // metadata followed by TimelyResponsex2
 			apmServerInternals.Data,
 		)
 	case <-time.After(timeout):


### PR DESCRIPTION
Go 1.22 has reached EOL.
We need to upgrade golangci-lint with it for compatibility reasons.