### PR TITLE
[docs] Update links to APM agent docs

### DIFF
--- a/docs/reference/aws-lambda-secrets-manager.md
+++ b/docs/reference/aws-lambda-secrets-manager.md
@@ -266,9 +266,9 @@ Provide the name of the secret you created in [Step 1](#aws-lambda-secrets-manag
 
 The language-specific instructions describe how to set environment variables for configuring AWS Lambda for Elastic APM:
 
-* [Configure APM on AWS Lambda - Node.js](apm-agent-nodejs://reference/lambda.md#_step_3_configure_apm_on_aws_lambda)
-* [Configure APM on AWS Lambda - Python](apm-agent-python://reference/lambda-support.md#_step_3_configure_apm_on_aws_lambda)
-* [Configure APM on AWS Lambda - Java](apm-agent-java://reference/aws-lambda.md#_step_3_configure_apm_on_aws_lambda)
+* [Configure APM on AWS Lambda - Node.js](apm-agent-nodejs://reference/lambda.md#configure_apm_on_aws_lambda)
+* [Configure APM on AWS Lambda - Python](apm-agent-python://reference/lambda-support.md#configure_apm_on_aws_lambda)
+* [Configure APM on AWS Lambda - Java](apm-agent-java://reference/aws-lambda.md#configure_apm_on_aws_lambda)
 
 That’s it. With the first invocation (cold start) of your Lambda function you should see a log message from the {{apm-lambda-ext}} indicating that a secret from the secrets manager is used:
 


### PR DESCRIPTION
Updates links to APM agent docs. The IDs they link to will be updated in:

* https://github.com/elastic/apm-agent-nodejs/pull/4479/commits/a6ed762b28e668d730e8c25486b22fb6d59f44ab
* https://github.com/elastic/apm-agent-java/pull/3981/commits/de7bc57c4e309cd9a7573eb2a01db18ec53195e1
* https://github.com/elastic/apm-agent-python/pull/2221/commits/e795df5d8275c4a7399b24546e83212c3c99a934