### PR TITLE
test: update e2e-testing/sam-nodejs deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ lint:
 NOTICE.txt: go.mod
 	@bash ./scripts/notice.sh
 
-.PHONY: check-linceses
+.PHONY: check-licenses
 check-licenses:
-	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing .
-	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing -ext .java .
-	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing -ext .js .
+	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing -exclude e2e-testing .
+	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing -exclude e2e-testing -ext .java .
+	@go run github.com/elastic/go-licenser@$(GO_LICENSER_VERSION) -d -exclude tf -exclude testing -exclude e2e-testing -ext .js .
 
 
 .PHONY: check-notice

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -13,7 +13,7 @@ In order to run the Lambda functions locally, the following dependencies must be
 ## Run
 
 ```shell
-cd apm-lambda-extension/e2e-testing
+cd e2e-testing
 go test
 ```
 

--- a/e2e-testing/sam-nodejs/sam-testing-nodejs/package.json
+++ b/e2e-testing/sam-nodejs/sam-testing-nodejs/package.json
@@ -7,14 +7,6 @@
   "author": "SAM CLI",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.28.1",
-    "elastic-apm-node": "^3.26.0"
-  },
-  "scripts": {
-    "test": "mocha tests/unit/"
-  },
-  "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^8.2.1"
+    "elastic-apm-node": "^4.11.0"
   }
 }

--- a/e2e-testing/sam-nodejs/template.yml
+++ b/e2e-testing/sam-nodejs/template.yml
@@ -28,7 +28,7 @@ Resources:
       Timeout: !Ref TimeoutParam
       CodeUri: sam-testing-nodejs/
       Handler: app.lambdaHandler
-      Runtime: nodejs14.x
+      Runtime: nodejs22.x
       Layers:
         - !Ref ElasticAPMExtensionLayer
       Architectures:


### PR DESCRIPTION
This removes deps not being used by the 'sam-testing-nodejs' package
used in e2e-testing. It bumps elastic-apm-node to its current major
version.

This also makes some attempts to get e2e-testing working again, but
ultimately I did not get far. e2e-testing looks to not have been
updated for changes in how the apm-lambda-extension is now built.

Obsoletes: #624
