### PR TITLE
[Test/draft] Move to projectbot for automatic labeling of issues and PRs

### DIFF
--- a/.github/project-bot.yml
+++ b/.github/project-bot.yml
@@ -1,0 +1,95 @@
+# Project Bot Configuration for APM AWS Lambda Extension
+# This configuration automates project management for issues and pull requests
+
+# Define project configuration
+project:
+  # Target project URL
+  url: "https://github.com/orgs/elastic/projects/454"
+  
+# Rules for automatically managing issues and pull requests
+rules:
+  # Rule for new issues
+  - name: "New Issues"
+    condition:
+      - type: "issue"
+        action: "opened"
+    actions:
+      - type: "add_to_project"
+        column: "To Do"
+        
+  # Rule for new internal pull requests  
+  - name: "New Internal PRs"
+    condition:
+      - type: "pull_request"
+        action: "opened"
+        author_association: ["MEMBER", "COLLABORATOR", "OWNER"]
+    actions:
+      - type: "add_to_project" 
+        column: "In Progress"
+        
+  # Rule for new community pull requests
+  - name: "New Community PRs"
+    condition:
+      - type: "pull_request"
+        action: "opened"
+        author_association: ["FIRST_TIME_CONTRIBUTOR", "CONTRIBUTOR", "NONE"]
+    actions:
+      - type: "add_to_project"
+        column: "Community Review"
+        
+  # Rule for when PRs are ready for review
+  - name: "Ready for Review"
+    condition:
+      - type: "pull_request"
+        action: "ready_for_review"
+    actions:
+      - type: "move_to_column"
+        column: "Review"
+        
+  # Rule for when PRs are converted to draft
+  - name: "Draft PRs"
+    condition:
+      - type: "pull_request"
+        action: "converted_to_draft"
+    actions:
+      - type: "move_to_column"
+        column: "In Progress"
+        
+  # Rule for closed issues and PRs
+  - name: "Completed Items"
+    condition:
+      - type: "issue"
+        action: "closed"
+      - type: "pull_request"
+        action: "closed"
+        merged: true
+    actions:
+      - type: "move_to_column"
+        column: "Done"
+        
+  # Rule for items with specific labels
+  - name: "Bug Issues"
+    condition:
+      - type: "issue"
+        labels: ["bug"]
+    actions:
+      - type: "add_to_project"
+        column: "Bug Triage"
+        
+  - name: "Enhancement Requests"
+    condition:
+      - type: "issue"
+        labels: ["enhancement", "feature-request"]
+    actions:
+      - type: "add_to_project"
+        column: "Backlog"
+
+# Columns that should exist in the project
+columns:
+  - "To Do"
+  - "In Progress" 
+  - "Review"
+  - "Community Review"
+  - "Bug Triage"
+  - "Backlog"
+  - "Done"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,17 +1,20 @@
-name: "Issue+PR Labeler"
+name: "Project Bot"
 on:
   issues:
-    types: [opened]
+    types: [opened, edited, closed, reopened, labeled, unlabeled]
   pull_request_target:
-    types: [opened]
+    types: [opened, edited, closed, reopened, labeled, unlabeled, ready_for_review, converted_to_draft]
+  project_card:
+    types: [created, moved, deleted]
 
 permissions:
   contents: read
   issues: write
   pull-requests: write
+  repository-projects: write
 
 jobs:
-  triage:
+  project_bot:
     runs-on: ubuntu-latest
     steps:
     - name: Get token
@@ -24,14 +27,24 @@ jobs:
           {
             "members": "read",
             "organization_projects": "write",
-            "issues": "read"
+            "issues": "write",
+            "pull_requests": "write",
+            "repository_projects": "write"
           }
+    
+    - name: Run Project Bot
+      uses: philschatz/project-bot@v1
+      with:
+        github-token: ${{ steps.get_token.outputs.token }}
+        config-path: .github/project-bot.yml
+        
     - name: Add aws-λ-extension label
       uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ steps.get_token.outputs.token }}"
         configuration-path: .github/labeler-config.yml
         enable-versioned-regex: 0
+        
     - name: Check team membership for user
       uses: elastic/get-user-teams-membership@5fa8d08135326e44d74d0ec4ef8705d8e36df12d # 1.1.0
       id: checkUserMember
@@ -42,23 +55,11 @@ jobs:
           apmmachine
           dependabot
         GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}
-    - name: Show team membership
-      run: |
-        echo "::debug::isTeamMember: ${{ steps.checkUserMember.outputs.isTeamMember }}"
-        echo "::debug::isExcluded: ${{ steps.checkUserMember.outputs.isExcluded }}"
+        
     - name: Add community and triage labels
       if: steps.checkUserMember.outputs.isTeamMember != 'true' && steps.checkUserMember.outputs.isExcluded != 'true'
       uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ steps.get_token.outputs.token }}"
         configuration-path: .github/community-label.yml
         enable-versioned-regex: 0
-    - name: Assign new internal pull requests to project
-      uses: elastic/assign-one-project-github-action@2573c8fb01aadfde8f5b653eea21dd24569ca831 # 1.2.2
-      if: (steps.checkUserMember.outputs.isTeamMember == 'true' || steps.checkUserMember.outputs.isExcluded == 'true') && github.event.pull_request
-      with:
-        project: 'https://github.com/orgs/elastic/projects/454'
-        project_id: '5882982'
-        column_name: 'In Progress'
-      env:
-        MY_GITHUB_TOKEN: ${{ steps.get_token.outputs.token }}


### PR DESCRIPTION
Fixes #669 by switching to [project-bot](https://github.com/philschatz/project-bot) for automatic labeling of issues and PRs.
