### PR TITLE
Start using elastic-observability-ci google cloud project for ci secrets

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -44,6 +44,9 @@ jobs:
           terraform_version: 1.2.3
       - uses: elastic/oblt-actions/aws/auth@v1
       - uses: elastic/oblt-actions/google/auth@v1
+        with:
+          project-id: 'elastic-observability-ci'
+          
       - uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
         with:
           export_to_environment: true

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: elastic/oblt-actions/aws/auth@v1
       - uses: elastic/oblt-actions/google/auth@v1
         with:
-          project-id: 'elastic-observability-ci'
+          project-number: '911195782929'
           
       - uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3.0.0
         with:


### PR DESCRIPTION
### Summary

Change the federation oidc for gcp on github actions and buildkite from `elastic-observability` to `elastic-observability-ci `since the support to create the Google Secrets for `elastic-cloud-observability-team-*` in the `elastic-observability-ci` has been added.

This is part of https://github.com/elastic/observability-robots/issues/2797

### What

Replace the gcp account for oidc federation by `elastic-observability-ci`

### Why

The secrets in the CI are not aimed to be accessed by Developers.